### PR TITLE
feat: add language selection in settings

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,17 +1,22 @@
 // app/app.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../core/presentation/l10n/locale_controller.dart';
 import '../l10n/app_localizations.dart';
 import 'presentation/app_shell.dart';
 
-class AsaServerEyeApp extends StatelessWidget {
+class AsaServerEyeApp extends ConsumerWidget {
   const AsaServerEyeApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locale = ref.watch(localeControllerProvider);
+
     return MaterialApp(
       debugShowCheckedModeBanner: false,
+      locale: locale,
       onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
       supportedLocales: AppLocalizations.supportedLocales,
       localizationsDelegates: const [

--- a/lib/core/presentation/l10n/locale_controller.dart
+++ b/lib/core/presentation/l10n/locale_controller.dart
@@ -1,0 +1,24 @@
+// core/presentation/l10n/locale_controller.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final localeControllerProvider =
+    StateNotifierProvider<LocaleController, Locale?>((ref) {
+      return LocaleController();
+    });
+
+class LocaleController extends StateNotifier<Locale?> {
+  LocaleController() : super(null);
+
+  void useSystemLocale() {
+    state = null;
+  }
+
+  void setGerman() {
+    state = const Locale('de');
+  }
+
+  void setEnglish() {
+    state = const Locale('en');
+  }
+}

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -1,13 +1,23 @@
 // features/settings/presentation/screens/settings_screen.dart
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/extensions/context_l10n.dart';
+import '../../../../core/presentation/l10n/locale_controller.dart';
 
-class SettingsScreen extends StatelessWidget {
+class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locale = ref.watch(localeControllerProvider);
+
+    final languageSubtitle = switch (locale?.languageCode) {
+      'de' => context.l10n.german,
+      'en' => context.l10n.english,
+      _ => context.l10n.systemLanguage,
+    };
+
     return Scaffold(
       appBar: AppBar(title: Text(context.l10n.settings)),
       body: ListView(
@@ -16,31 +26,110 @@ class SettingsScreen extends StatelessWidget {
           _SettingsTile(
             icon: Icons.language,
             title: context.l10n.language,
-            subtitle: context.l10n.systemDefault,
+            subtitle: languageSubtitle,
+            onTap: () => _showLanguageDialog(context, ref),
           ),
           _SettingsTile(
             icon: Icons.info_outline,
             title: context.l10n.about,
             subtitle: context.l10n.appInformation,
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(context.l10n.comingSoon(context.l10n.about)),
+                ),
+              );
+            },
           ),
           _SettingsSectionHeader(title: context.l10n.legal),
           _SettingsTile(
             icon: Icons.privacy_tip_outlined,
             title: context.l10n.privacyPolicy,
             subtitle: context.l10n.howDataIsHandled,
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    context.l10n.comingSoon(context.l10n.privacyPolicy),
+                  ),
+                ),
+              );
+            },
           ),
           _SettingsTile(
             icon: Icons.gavel_outlined,
             title: context.l10n.imprint,
             subtitle: context.l10n.legalInformation,
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(context.l10n.comingSoon(context.l10n.imprint)),
+                ),
+              );
+            },
           ),
           _SettingsTile(
             icon: Icons.support_agent,
             title: context.l10n.support,
             subtitle: context.l10n.getHelpAndContactSupport,
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(context.l10n.comingSoon(context.l10n.support)),
+                ),
+              );
+            },
           ),
         ],
       ),
+    );
+  }
+
+  Future<void> _showLanguageDialog(BuildContext context, WidgetRef ref) async {
+    final controller = ref.read(localeControllerProvider.notifier);
+    final currentLocale = ref.read(localeControllerProvider);
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        final currentCode = currentLocale?.languageCode;
+
+        return AlertDialog(
+          title: Text(context.l10n.selectLanguage),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              RadioListTile<String?>(
+                value: null,
+                groupValue: currentCode,
+                title: Text(context.l10n.systemLanguage),
+                onChanged: (_) {
+                  controller.useSystemLocale();
+                  Navigator.of(dialogContext).pop();
+                },
+              ),
+              RadioListTile<String?>(
+                value: 'de',
+                groupValue: currentCode,
+                title: Text(context.l10n.german),
+                onChanged: (_) {
+                  controller.setGerman();
+                  Navigator.of(dialogContext).pop();
+                },
+              ),
+              RadioListTile<String?>(
+                value: 'en',
+                groupValue: currentCode,
+                title: Text(context.l10n.english),
+                onChanged: (_) {
+                  controller.setEnglish();
+                  Navigator.of(dialogContext).pop();
+                },
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }
@@ -64,11 +153,13 @@ class _SettingsTile extends StatelessWidget {
     required this.icon,
     required this.title,
     required this.subtitle,
+    required this.onTap,
   });
 
   final IconData icon;
   final String title;
   final String subtitle;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -77,11 +168,7 @@ class _SettingsTile extends StatelessWidget {
       title: Text(title),
       subtitle: Text(subtitle),
       trailing: const Icon(Icons.chevron_right),
-      onTap: () {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(context.l10n.comingSoon(title))));
-      },
+      onTap: onTap,
     );
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -162,5 +162,21 @@
         "type": "String"
       }
     }
+  },
+  "systemLanguage": "Systemsprache",
+  "@systemLanguage": {
+    "description": "Sprachoption für die Systemsprache"
+  },
+  "german": "Deutsch",
+  "@german": {
+    "description": "Sprachoption für Deutsch"
+  },
+  "english": "Englisch",
+  "@english": {
+    "description": "Sprachoption für Englisch"
+  },
+  "selectLanguage": "Sprache auswählen",
+  "@selectLanguage": {
+    "description": "Dialogtitel für die Sprachauswahl"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -162,5 +162,21 @@
         "type": "String"
       }
     }
+  },
+  "systemLanguage": "System language",
+  "@systemLanguage": {
+    "description": "Language option for following the system language"
+  },
+  "german": "German",
+  "@german": {
+    "description": "Language option for German"
+  },
+  "english": "English",
+  "@english": {
+    "description": "Language option for English"
+  },
+  "selectLanguage": "Select language",
+  "@selectLanguage": {
+    "description": "Dialog title for language selection"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -316,6 +316,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{title} coming soon'**
   String comingSoon(String title);
+
+  /// Language option for following the system language
+  ///
+  /// In en, this message translates to:
+  /// **'System language'**
+  String get systemLanguage;
+
+  /// Language option for German
+  ///
+  /// In en, this message translates to:
+  /// **'German'**
+  String get german;
+
+  /// Language option for English
+  ///
+  /// In en, this message translates to:
+  /// **'English'**
+  String get english;
+
+  /// Dialog title for language selection
+  ///
+  /// In en, this message translates to:
+  /// **'Select language'**
+  String get selectLanguage;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -124,4 +124,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String comingSoon(String title) {
     return '$title kommt bald';
   }
+
+  @override
+  String get systemLanguage => 'Systemsprache';
+
+  @override
+  String get german => 'Deutsch';
+
+  @override
+  String get english => 'Englisch';
+
+  @override
+  String get selectLanguage => 'Sprache auswählen';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -124,4 +124,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String comingSoon(String title) {
     return '$title coming soon';
   }
+
+  @override
+  String get systemLanguage => 'System language';
+
+  @override
+  String get german => 'German';
+
+  @override
+  String get english => 'English';
+
+  @override
+  String get selectLanguage => 'Select language';
 }


### PR DESCRIPTION
## Summary
Add manual language selection to the settings screen.

## Changes
- added locale controller with Riverpod
- connected MaterialApp locale to app state
- added system, German and English language options
- added localized language selection dialog in settings

Closes #9

## Summary by Sourcery

Fügen Sie eine manuelle, app-weite Sprachauswahl hinzu und machen Sie sie im Einstellungsbildschirm verfügbar.

Neue Funktionen:
- Ermöglicht es Benutzer:innen, über einen Sprachauswahldialog im Einstellungsbildschirm zwischen Systemsprache, Deutsch und Englisch zu wählen.
- Bindet die Locale der `MaterialApp` der App an einen Riverpod-basierten Locale-Controller, um Sprachänderungen zu speichern und darauf zu reagieren.

Verbesserungen:
- Überarbeitet die Einstellungs-Kacheln, sodass sie benutzerdefinierte Tipp-Handler anstelle einer hartkodierten Platzhalteraktion akzeptieren.
- Fügt lokalisierte Zeichenketten für Sprachnamen und den Titel des Sprachauswahldialogs in Englisch und Deutsch hinzu.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add app-wide manual locale selection and expose it in the settings screen.

New Features:
- Allow users to choose between system language, German, and English from the settings screen via a language selection dialog.
- Bind the app's MaterialApp locale to a Riverpod-backed locale controller to persist and react to language changes.

Enhancements:
- Refactor settings tiles to accept custom tap handlers instead of a hardcoded placeholder action.
- Add localized strings for language names and the language selection dialog title in English and German.

</details>