### PR TITLE
feat: add language selection with de en es zh support

### DIFF
--- a/lib/core/presentation/l10n/locale_controller.dart
+++ b/lib/core/presentation/l10n/locale_controller.dart
@@ -21,4 +21,12 @@ class LocaleController extends StateNotifier<Locale?> {
   void setEnglish() {
     state = const Locale('en');
   }
+
+  void setSpanish() {
+    state = const Locale('es');
+  }
+
+  void setChinese() {
+    state = const Locale('zh');
+  }
 }

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -1,4 +1,7 @@
 // features/settings/presentation/screens/settings_screen.dart
+import 'package:ark_server_eye/features/settings/presentation/widgets/language_dialog.dart';
+import 'package:ark_server_eye/features/settings/presentation/widgets/settings_section_header.dart';
+import 'package:ark_server_eye/features/settings/presentation/widgets/settings_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -15,6 +18,8 @@ class SettingsScreen extends ConsumerWidget {
     final languageSubtitle = switch (locale?.languageCode) {
       'de' => context.l10n.german,
       'en' => context.l10n.english,
+      'es' => context.l10n.spanish,
+      'zh' => context.l10n.chinese,
       _ => context.l10n.systemLanguage,
     };
 
@@ -22,153 +27,47 @@ class SettingsScreen extends ConsumerWidget {
       appBar: AppBar(title: Text(context.l10n.settings)),
       body: ListView(
         children: [
-          _SettingsSectionHeader(title: context.l10n.general),
-          _SettingsTile(
+          SettingsSectionHeader(title: context.l10n.general),
+          SettingsTile(
             icon: Icons.language,
             title: context.l10n.language,
             subtitle: languageSubtitle,
-            onTap: () => _showLanguageDialog(context, ref),
+            onTap: () => showLanguageDialog(context, ref),
           ),
-          _SettingsTile(
+          SettingsTile(
             icon: Icons.info_outline,
             title: context.l10n.about,
             subtitle: context.l10n.appInformation,
-            onTap: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(context.l10n.comingSoon(context.l10n.about)),
-                ),
-              );
-            },
+            onTap: () => _showComingSoonSnackBar(context, context.l10n.about),
           ),
-          _SettingsSectionHeader(title: context.l10n.legal),
-          _SettingsTile(
+          SettingsSectionHeader(title: context.l10n.legal),
+          SettingsTile(
             icon: Icons.privacy_tip_outlined,
             title: context.l10n.privacyPolicy,
             subtitle: context.l10n.howDataIsHandled,
-            onTap: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(
-                    context.l10n.comingSoon(context.l10n.privacyPolicy),
-                  ),
-                ),
-              );
-            },
+            onTap: () =>
+                _showComingSoonSnackBar(context, context.l10n.privacyPolicy),
           ),
-          _SettingsTile(
+          SettingsTile(
             icon: Icons.gavel_outlined,
             title: context.l10n.imprint,
             subtitle: context.l10n.legalInformation,
-            onTap: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(context.l10n.comingSoon(context.l10n.imprint)),
-                ),
-              );
-            },
+            onTap: () => _showComingSoonSnackBar(context, context.l10n.imprint),
           ),
-          _SettingsTile(
+          SettingsTile(
             icon: Icons.support_agent,
             title: context.l10n.support,
             subtitle: context.l10n.getHelpAndContactSupport,
-            onTap: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(context.l10n.comingSoon(context.l10n.support)),
-                ),
-              );
-            },
+            onTap: () => _showComingSoonSnackBar(context, context.l10n.support),
           ),
         ],
       ),
     );
   }
 
-  Future<void> _showLanguageDialog(BuildContext context, WidgetRef ref) async {
-    final controller = ref.read(localeControllerProvider.notifier);
-    final currentLocale = ref.read(localeControllerProvider);
-
-    await showDialog<void>(
-      context: context,
-      builder: (dialogContext) {
-        final currentCode = currentLocale?.languageCode;
-
-        return AlertDialog(
-          title: Text(context.l10n.selectLanguage),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              RadioListTile<String?>(
-                value: null,
-                groupValue: currentCode,
-                title: Text(context.l10n.systemLanguage),
-                onChanged: (_) {
-                  controller.useSystemLocale();
-                  Navigator.of(dialogContext).pop();
-                },
-              ),
-              RadioListTile<String?>(
-                value: 'de',
-                groupValue: currentCode,
-                title: Text(context.l10n.german),
-                onChanged: (_) {
-                  controller.setGerman();
-                  Navigator.of(dialogContext).pop();
-                },
-              ),
-              RadioListTile<String?>(
-                value: 'en',
-                groupValue: currentCode,
-                title: Text(context.l10n.english),
-                onChanged: (_) {
-                  controller.setEnglish();
-                  Navigator.of(dialogContext).pop();
-                },
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-}
-
-class _SettingsSectionHeader extends StatelessWidget {
-  const _SettingsSectionHeader({required this.title});
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
-      child: Text(title, style: Theme.of(context).textTheme.titleSmall),
-    );
-  }
-}
-
-class _SettingsTile extends StatelessWidget {
-  const _SettingsTile({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-    required this.onTap,
-  });
-
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      leading: Icon(icon),
-      title: Text(title),
-      subtitle: Text(subtitle),
-      trailing: const Icon(Icons.chevron_right),
-      onTap: onTap,
+  void _showComingSoonSnackBar(BuildContext context, String featureName) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(context.l10n.comingSoon(featureName))),
     );
   }
 }

--- a/lib/features/settings/presentation/widgets/language_dialog.dart
+++ b/lib/features/settings/presentation/widgets/language_dialog.dart
@@ -1,0 +1,81 @@
+// features/settings/presentation/widgets/language_dialog.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/extensions/context_l10n.dart';
+import '../../../../core/presentation/l10n/locale_controller.dart';
+
+enum AppLanguageOption { system, german, english, spanish, chinese }
+
+Future<void> showLanguageDialog(BuildContext context, WidgetRef ref) async {
+  final controller = ref.read(localeControllerProvider.notifier);
+  final currentLocale = ref.read(localeControllerProvider);
+
+  final currentOption = switch (currentLocale?.languageCode) {
+    'de' => AppLanguageOption.german,
+    'en' => AppLanguageOption.english,
+    'es' => AppLanguageOption.spanish,
+    'zh' => AppLanguageOption.chinese,
+    _ => AppLanguageOption.system,
+  };
+
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(context.l10n.selectLanguage),
+        content: RadioGroup<AppLanguageOption>(
+          groupValue: currentOption,
+          onChanged: (value) {
+            if (value == null) return;
+
+            switch (value) {
+              case AppLanguageOption.system:
+                controller.useSystemLocale();
+                break;
+              case AppLanguageOption.german:
+                controller.setGerman();
+                break;
+              case AppLanguageOption.english:
+                controller.setEnglish();
+                break;
+              case AppLanguageOption.spanish:
+                controller.setSpanish();
+                break;
+              case AppLanguageOption.chinese:
+                controller.setChinese();
+                break;
+            }
+
+            Navigator.of(dialogContext).pop();
+          },
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              RadioListTile<AppLanguageOption>(
+                value: AppLanguageOption.system,
+                title: Text(context.l10n.systemLanguage),
+              ),
+              RadioListTile<AppLanguageOption>(
+                value: AppLanguageOption.german,
+                title: Text(context.l10n.german),
+              ),
+              RadioListTile<AppLanguageOption>(
+                value: AppLanguageOption.english,
+                title: Text(context.l10n.english),
+              ),
+              RadioListTile<AppLanguageOption>(
+                value: AppLanguageOption.spanish,
+                title: Text(context.l10n.spanish),
+              ),
+              RadioListTile<AppLanguageOption>(
+                value: AppLanguageOption.chinese,
+                title: Text(context.l10n.chinese),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/lib/features/settings/presentation/widgets/settings_section_header.dart
+++ b/lib/features/settings/presentation/widgets/settings_section_header.dart
@@ -1,0 +1,16 @@
+// features/settings/presentation/widgets/settings_section_header.dart
+import 'package:flutter/material.dart';
+
+class SettingsSectionHeader extends StatelessWidget {
+  const SettingsSectionHeader({super.key, required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+      child: Text(title, style: Theme.of(context).textTheme.titleSmall),
+    );
+  }
+}

--- a/lib/features/settings/presentation/widgets/settings_tile.dart
+++ b/lib/features/settings/presentation/widgets/settings_tile.dart
@@ -1,0 +1,28 @@
+// features/settings/presentation/widgets/settings_tile.dart
+import 'package:flutter/material.dart';
+
+class SettingsTile extends StatelessWidget {
+  const SettingsTile({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(title),
+      subtitle: Text(subtitle),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -88,6 +88,10 @@
   "@remove": {
     "description": "Entfernen-Aktion"
   },
+  "apply": "Anwenden",
+  "@apply": {
+    "description": "Anwenden-Aktion"
+  },
   "removeFavoriteQuestion": "Möchtest du „{serverName}“ aus den Favoriten entfernen?",
   "@removeFavoriteQuestion": {
     "description": "Bestätigungsfrage vor dem Entfernen eines Favoriten",
@@ -117,6 +121,30 @@
   "systemDefault": "Systemstandard",
   "@systemDefault": {
     "description": "Untertitel für Spracheinstellung"
+  },
+  "systemLanguage": "Systemsprache",
+  "@systemLanguage": {
+    "description": "Sprachoption für die Systemsprache"
+  },
+  "german": "Deutsch",
+  "@german": {
+    "description": "Sprachoption für Deutsch"
+  },
+  "english": "Englisch",
+  "@english": {
+    "description": "Sprachoption für Englisch"
+  },
+  "spanish": "Spanisch",
+  "@spanish": {
+    "description": "Sprachoption für Spanisch"
+  },
+  "chinese": "Chinesisch",
+  "@chinese": {
+    "description": "Sprachoption für Chinesisch"
+  },
+  "selectLanguage": "Sprache auswählen",
+  "@selectLanguage": {
+    "description": "Dialogtitel für die Sprachauswahl"
   },
   "about": "Über die App",
   "@about": {
@@ -162,21 +190,5 @@
         "type": "String"
       }
     }
-  },
-  "systemLanguage": "Systemsprache",
-  "@systemLanguage": {
-    "description": "Sprachoption für die Systemsprache"
-  },
-  "german": "Deutsch",
-  "@german": {
-    "description": "Sprachoption für Deutsch"
-  },
-  "english": "Englisch",
-  "@english": {
-    "description": "Sprachoption für Englisch"
-  },
-  "selectLanguage": "Sprache auswählen",
-  "@selectLanguage": {
-    "description": "Dialogtitel für die Sprachauswahl"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -88,6 +88,10 @@
   "@remove": {
     "description": "Remove action"
   },
+  "apply": "Apply",
+  "@apply": {
+    "description": "Apply action"
+  },
   "removeFavoriteQuestion": "Do you want to remove \"{serverName}\" from favorites?",
   "@removeFavoriteQuestion": {
     "description": "Confirmation message before removing a favorite",
@@ -117,6 +121,30 @@
   "systemDefault": "System default",
   "@systemDefault": {
     "description": "Settings entry subtitle"
+  },
+  "systemLanguage": "System language",
+  "@systemLanguage": {
+    "description": "Language option for following the system language"
+  },
+  "german": "German",
+  "@german": {
+    "description": "Language option for German"
+  },
+  "english": "English",
+  "@english": {
+    "description": "Language option for English"
+  },
+  "spanish": "Spanish",
+  "@spanish": {
+    "description": "Language option for Spanish"
+  },
+  "chinese": "Chinese",
+  "@chinese": {
+    "description": "Language option for Chinese"
+  },
+  "selectLanguage": "Select language",
+  "@selectLanguage": {
+    "description": "Dialog title for language selection"
   },
   "about": "About",
   "@about": {
@@ -162,21 +190,5 @@
         "type": "String"
       }
     }
-  },
-  "systemLanguage": "System language",
-  "@systemLanguage": {
-    "description": "Language option for following the system language"
-  },
-  "german": "German",
-  "@german": {
-    "description": "Language option for German"
-  },
-  "english": "English",
-  "@english": {
-    "description": "Language option for English"
-  },
-  "selectLanguage": "Select language",
-  "@selectLanguage": {
-    "description": "Dialog title for language selection"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,0 +1,194 @@
+{
+    "@@locale": "es",
+    "appTitle": "ASA Server Eye",
+    "@appTitle": {
+        "description": "El nombre de la aplicación"
+    },
+    "servers": "Servidores",
+    "@servers": {
+        "description": "Título de pantalla y navegación inferior para servidores"
+    },
+    "favorites": "Favoritos",
+    "@favorites": {
+        "description": "Título de pantalla y navegación inferior para favoritos"
+    },
+    "settings": "Ajustes",
+    "@settings": {
+        "description": "Título de pantalla y navegación inferior para ajustes"
+    },
+    "searchServersOrMaps": "Buscar servidores o mapas",
+    "@searchServersOrMaps": {
+        "description": "Texto de ayuda del campo de búsqueda"
+    },
+    "noServersFound": "No se encontraron servidores",
+    "@noServersFound": {
+        "description": "Estado vacío cuando no hay servidores disponibles"
+    },
+    "noServersMatchSearch": "Ningún servidor coincide con tu búsqueda",
+    "@noServersMatchSearch": {
+        "description": "Estado vacío cuando la búsqueda no devuelve resultados"
+    },
+    "serverDetails": "Detalles del servidor",
+    "@serverDetails": {
+        "description": "Título de la pantalla de detalles del servidor"
+    },
+    "serverNotFound": "Servidor no encontrado",
+    "@serverNotFound": {
+        "description": "Se muestra cuando no se encuentra un servidor"
+    },
+    "map": "Mapa",
+    "@map": {
+        "description": "Etiqueta del mapa"
+    },
+    "population": "Población",
+    "@population": {
+        "description": "Etiqueta de la población del servidor"
+    },
+    "type": "Tipo",
+    "@type": {
+        "description": "Etiqueta del tipo de servidor"
+    },
+    "official": "Oficial",
+    "@official": {
+        "description": "Tipo de servidor oficial"
+    },
+    "unofficial": "No oficial",
+    "@unofficial": {
+        "description": "Tipo de servidor no oficial"
+    },
+    "addToFavorites": "Añadir a favoritos",
+    "@addToFavorites": {
+        "description": "Botón para añadir a favoritos"
+    },
+    "removeFromFavorites": "Quitar de favoritos",
+    "@removeFromFavorites": {
+        "description": "Botón para quitar de favoritos"
+    },
+    "addedToFavorites": "Añadido a favoritos",
+    "@addedToFavorites": {
+        "description": "Snackbar al añadir favorito"
+    },
+    "removedFromFavorites": "Eliminado de favoritos",
+    "@removedFromFavorites": {
+        "description": "Snackbar al eliminar favorito"
+    },
+    "noFavoritesYet": "Todavía no hay favoritos",
+    "@noFavoritesYet": {
+        "description": "Estado vacío de favoritos"
+    },
+    "removeFavorite": "Eliminar favorito",
+    "@removeFavorite": {
+        "description": "Título del diálogo para eliminar favorito"
+    },
+    "cancel": "Cancelar",
+    "@cancel": {
+        "description": "Acción de cancelar"
+    },
+    "remove": "Eliminar",
+    "@remove": {
+        "description": "Acción de eliminar"
+    },
+    "apply": "Aplicar",
+    "@apply": {
+        "description": "Acción de aplicar"
+    },
+    "removeFavoriteQuestion": "¿Quieres eliminar \"{serverName}\" de favoritos?",
+    "@removeFavoriteQuestion": {
+        "description": "Pregunta de confirmación antes de eliminar un favorito",
+        "placeholders": {
+            "serverName": {
+                "type": "String"
+            }
+        }
+    },
+    "removedServerFromFavorites": "{serverName} eliminado de favoritos",
+    "@removedServerFromFavorites": {
+        "description": "Snackbar después de eliminar deslizando",
+        "placeholders": {
+            "serverName": {
+                "type": "String"
+            }
+        }
+    },
+    "general": "General",
+    "@general": {
+        "description": "Título de sección en ajustes"
+    },
+    "language": "Idioma",
+    "@language": {
+        "description": "Título del ajuste de idioma"
+    },
+    "systemDefault": "Predeterminado del sistema",
+    "@systemDefault": {
+        "description": "Subtítulo del ajuste de idioma"
+    },
+    "systemLanguage": "Idioma del sistema",
+    "@systemLanguage": {
+        "description": "Opción para seguir el idioma del sistema"
+    },
+    "german": "Alemán",
+    "@german": {
+        "description": "Opción de idioma alemán"
+    },
+    "english": "Inglés",
+    "@english": {
+        "description": "Opción de idioma inglés"
+    },
+    "spanish": "Español",
+    "@spanish": {
+        "description": "Opción de idioma español"
+    },
+    "chinese": "Chino",
+    "@chinese": {
+        "description": "Opción de idioma chino"
+    },
+    "selectLanguage": "Seleccionar idioma",
+    "@selectLanguage": {
+        "description": "Título del diálogo de idioma"
+    },
+    "about": "Acerca de",
+    "@about": {
+        "description": "Título del ajuste de información"
+    },
+    "appInformation": "Información de la aplicación",
+    "@appInformation": {
+        "description": "Subtítulo del ajuste de información"
+    },
+    "legal": "Legal",
+    "@legal": {
+        "description": "Título de sección legal"
+    },
+    "privacyPolicy": "Política de privacidad",
+    "@privacyPolicy": {
+        "description": "Título del ajuste de privacidad"
+    },
+    "howDataIsHandled": "Cómo se gestionan los datos",
+    "@howDataIsHandled": {
+        "description": "Subtítulo del ajuste de privacidad"
+    },
+    "imprint": "Aviso legal",
+    "@imprint": {
+        "description": "Título del ajuste de aviso legal"
+    },
+    "legalInformation": "Información legal",
+    "@legalInformation": {
+        "description": "Subtítulo del ajuste legal"
+    },
+    "support": "Soporte",
+    "@support": {
+        "description": "Título del ajuste de soporte"
+    },
+    "getHelpAndContactSupport": "Obtener ayuda y contactar con soporte",
+    "@getHelpAndContactSupport": {
+        "description": "Subtítulo del ajuste de soporte"
+    },
+    "comingSoon": "{title} próximamente",
+    "@comingSoon": {
+        "description": "Snackbar para funciones no implementadas",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    }
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'app_localizations_de.dart';
 import 'app_localizations_en.dart';
+import 'app_localizations_es.dart';
+import 'app_localizations_zh.dart';
 
 // ignore_for_file: type=lint
 
@@ -92,7 +94,9 @@ abstract class AppLocalizations {
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('de'),
-    Locale('en')
+    Locale('en'),
+    Locale('es'),
+    Locale('zh')
   ];
 
   /// The application name
@@ -227,6 +231,12 @@ abstract class AppLocalizations {
   /// **'Remove'**
   String get remove;
 
+  /// Apply action
+  ///
+  /// In en, this message translates to:
+  /// **'Apply'**
+  String get apply;
+
   /// Confirmation message before removing a favorite
   ///
   /// In en, this message translates to:
@@ -256,6 +266,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'System default'**
   String get systemDefault;
+
+  /// Language option for following the system language
+  ///
+  /// In en, this message translates to:
+  /// **'System language'**
+  String get systemLanguage;
+
+  /// Language option for German
+  ///
+  /// In en, this message translates to:
+  /// **'German'**
+  String get german;
+
+  /// Language option for English
+  ///
+  /// In en, this message translates to:
+  /// **'English'**
+  String get english;
+
+  /// Language option for Spanish
+  ///
+  /// In en, this message translates to:
+  /// **'Spanish'**
+  String get spanish;
+
+  /// Language option for Chinese
+  ///
+  /// In en, this message translates to:
+  /// **'Chinese'**
+  String get chinese;
+
+  /// Dialog title for language selection
+  ///
+  /// In en, this message translates to:
+  /// **'Select language'**
+  String get selectLanguage;
 
   /// Settings entry title
   ///
@@ -316,30 +362,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{title} coming soon'**
   String comingSoon(String title);
-
-  /// Language option for following the system language
-  ///
-  /// In en, this message translates to:
-  /// **'System language'**
-  String get systemLanguage;
-
-  /// Language option for German
-  ///
-  /// In en, this message translates to:
-  /// **'German'**
-  String get german;
-
-  /// Language option for English
-  ///
-  /// In en, this message translates to:
-  /// **'English'**
-  String get english;
-
-  /// Dialog title for language selection
-  ///
-  /// In en, this message translates to:
-  /// **'Select language'**
-  String get selectLanguage;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
@@ -351,7 +373,7 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['de', 'en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['de', 'en', 'es', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -364,6 +386,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   switch (locale.languageCode) {
     case 'de': return AppLocalizationsDe();
     case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
+    case 'zh': return AppLocalizationsZh();
   }
 
   throw FlutterError(

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -75,6 +75,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get remove => 'Entfernen';
 
   @override
+  String get apply => 'Anwenden';
+
+  @override
   String removeFavoriteQuestion(String serverName) {
     return 'Möchtest du „$serverName“ aus den Favoriten entfernen?';
   }
@@ -92,6 +95,24 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get systemDefault => 'Systemstandard';
+
+  @override
+  String get systemLanguage => 'Systemsprache';
+
+  @override
+  String get german => 'Deutsch';
+
+  @override
+  String get english => 'Englisch';
+
+  @override
+  String get spanish => 'Spanisch';
+
+  @override
+  String get chinese => 'Chinesisch';
+
+  @override
+  String get selectLanguage => 'Sprache auswählen';
 
   @override
   String get about => 'Über die App';
@@ -124,16 +145,4 @@ class AppLocalizationsDe extends AppLocalizations {
   String comingSoon(String title) {
     return '$title kommt bald';
   }
-
-  @override
-  String get systemLanguage => 'Systemsprache';
-
-  @override
-  String get german => 'Deutsch';
-
-  @override
-  String get english => 'Englisch';
-
-  @override
-  String get selectLanguage => 'Sprache auswählen';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -75,6 +75,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get remove => 'Remove';
 
   @override
+  String get apply => 'Apply';
+
+  @override
   String removeFavoriteQuestion(String serverName) {
     return 'Do you want to remove \"$serverName\" from favorites?';
   }
@@ -92,6 +95,24 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get systemDefault => 'System default';
+
+  @override
+  String get systemLanguage => 'System language';
+
+  @override
+  String get german => 'German';
+
+  @override
+  String get english => 'English';
+
+  @override
+  String get spanish => 'Spanish';
+
+  @override
+  String get chinese => 'Chinese';
+
+  @override
+  String get selectLanguage => 'Select language';
 
   @override
   String get about => 'About';
@@ -124,16 +145,4 @@ class AppLocalizationsEn extends AppLocalizations {
   String comingSoon(String title) {
     return '$title coming soon';
   }
-
-  @override
-  String get systemLanguage => 'System language';
-
-  @override
-  String get german => 'German';
-
-  @override
-  String get english => 'English';
-
-  @override
-  String get selectLanguage => 'Select language';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1,0 +1,148 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Spanish Castilian (`es`).
+class AppLocalizationsEs extends AppLocalizations {
+  AppLocalizationsEs([String locale = 'es']) : super(locale);
+
+  @override
+  String get appTitle => 'ASA Server Eye';
+
+  @override
+  String get servers => 'Servidores';
+
+  @override
+  String get favorites => 'Favoritos';
+
+  @override
+  String get settings => 'Ajustes';
+
+  @override
+  String get searchServersOrMaps => 'Buscar servidores o mapas';
+
+  @override
+  String get noServersFound => 'No se encontraron servidores';
+
+  @override
+  String get noServersMatchSearch => 'Ningún servidor coincide con tu búsqueda';
+
+  @override
+  String get serverDetails => 'Detalles del servidor';
+
+  @override
+  String get serverNotFound => 'Servidor no encontrado';
+
+  @override
+  String get map => 'Mapa';
+
+  @override
+  String get population => 'Población';
+
+  @override
+  String get type => 'Tipo';
+
+  @override
+  String get official => 'Oficial';
+
+  @override
+  String get unofficial => 'No oficial';
+
+  @override
+  String get addToFavorites => 'Añadir a favoritos';
+
+  @override
+  String get removeFromFavorites => 'Quitar de favoritos';
+
+  @override
+  String get addedToFavorites => 'Añadido a favoritos';
+
+  @override
+  String get removedFromFavorites => 'Eliminado de favoritos';
+
+  @override
+  String get noFavoritesYet => 'Todavía no hay favoritos';
+
+  @override
+  String get removeFavorite => 'Eliminar favorito';
+
+  @override
+  String get cancel => 'Cancelar';
+
+  @override
+  String get remove => 'Eliminar';
+
+  @override
+  String get apply => 'Aplicar';
+
+  @override
+  String removeFavoriteQuestion(String serverName) {
+    return '¿Quieres eliminar \"$serverName\" de favoritos?';
+  }
+
+  @override
+  String removedServerFromFavorites(String serverName) {
+    return '$serverName eliminado de favoritos';
+  }
+
+  @override
+  String get general => 'General';
+
+  @override
+  String get language => 'Idioma';
+
+  @override
+  String get systemDefault => 'Predeterminado del sistema';
+
+  @override
+  String get systemLanguage => 'Idioma del sistema';
+
+  @override
+  String get german => 'Alemán';
+
+  @override
+  String get english => 'Inglés';
+
+  @override
+  String get spanish => 'Español';
+
+  @override
+  String get chinese => 'Chino';
+
+  @override
+  String get selectLanguage => 'Seleccionar idioma';
+
+  @override
+  String get about => 'Acerca de';
+
+  @override
+  String get appInformation => 'Información de la aplicación';
+
+  @override
+  String get legal => 'Legal';
+
+  @override
+  String get privacyPolicy => 'Política de privacidad';
+
+  @override
+  String get howDataIsHandled => 'Cómo se gestionan los datos';
+
+  @override
+  String get imprint => 'Aviso legal';
+
+  @override
+  String get legalInformation => 'Información legal';
+
+  @override
+  String get support => 'Soporte';
+
+  @override
+  String get getHelpAndContactSupport => 'Obtener ayuda y contactar con soporte';
+
+  @override
+  String comingSoon(String title) {
+    return '$title próximamente';
+  }
+}

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1,0 +1,148 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Chinese (`zh`).
+class AppLocalizationsZh extends AppLocalizations {
+  AppLocalizationsZh([String locale = 'zh']) : super(locale);
+
+  @override
+  String get appTitle => 'ASA Server Eye';
+
+  @override
+  String get servers => '服务器';
+
+  @override
+  String get favorites => '收藏';
+
+  @override
+  String get settings => '设置';
+
+  @override
+  String get searchServersOrMaps => '搜索服务器或地图';
+
+  @override
+  String get noServersFound => '未找到服务器';
+
+  @override
+  String get noServersMatchSearch => '没有服务器符合你的搜索';
+
+  @override
+  String get serverDetails => '服务器详情';
+
+  @override
+  String get serverNotFound => '未找到服务器';
+
+  @override
+  String get map => '地图';
+
+  @override
+  String get population => '人数';
+
+  @override
+  String get type => '类型';
+
+  @override
+  String get official => '官方';
+
+  @override
+  String get unofficial => '非官方';
+
+  @override
+  String get addToFavorites => '添加到收藏';
+
+  @override
+  String get removeFromFavorites => '从收藏中移除';
+
+  @override
+  String get addedToFavorites => '已添加到收藏';
+
+  @override
+  String get removedFromFavorites => '已从收藏中移除';
+
+  @override
+  String get noFavoritesYet => '还没有收藏';
+
+  @override
+  String get removeFavorite => '移除收藏';
+
+  @override
+  String get cancel => '取消';
+
+  @override
+  String get remove => '移除';
+
+  @override
+  String get apply => '应用';
+
+  @override
+  String removeFavoriteQuestion(String serverName) {
+    return '要将“$serverName”从收藏中移除吗？';
+  }
+
+  @override
+  String removedServerFromFavorites(String serverName) {
+    return '$serverName 已从收藏中移除';
+  }
+
+  @override
+  String get general => '通用';
+
+  @override
+  String get language => '语言';
+
+  @override
+  String get systemDefault => '系统默认';
+
+  @override
+  String get systemLanguage => '系统语言';
+
+  @override
+  String get german => '德语';
+
+  @override
+  String get english => '英语';
+
+  @override
+  String get spanish => '西班牙语';
+
+  @override
+  String get chinese => '中文';
+
+  @override
+  String get selectLanguage => '选择语言';
+
+  @override
+  String get about => '关于';
+
+  @override
+  String get appInformation => '应用信息';
+
+  @override
+  String get legal => '法律信息';
+
+  @override
+  String get privacyPolicy => '隐私政策';
+
+  @override
+  String get howDataIsHandled => '数据如何处理';
+
+  @override
+  String get imprint => '法律声明';
+
+  @override
+  String get legalInformation => '法律信息';
+
+  @override
+  String get support => '支持';
+
+  @override
+  String get getHelpAndContactSupport => '获取帮助并联系支持';
+
+  @override
+  String comingSoon(String title) {
+    return '$title 即将推出';
+  }
+}

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,0 +1,194 @@
+{
+    "@@locale": "zh",
+    "appTitle": "ASA Server Eye",
+    "@appTitle": {
+        "description": "应用名称"
+    },
+    "servers": "服务器",
+    "@servers": {
+        "description": "服务器页面和底部导航标题"
+    },
+    "favorites": "收藏",
+    "@favorites": {
+        "description": "收藏页面和底部导航标题"
+    },
+    "settings": "设置",
+    "@settings": {
+        "description": "设置页面和底部导航标题"
+    },
+    "searchServersOrMaps": "搜索服务器或地图",
+    "@searchServersOrMaps": {
+        "description": "搜索框提示文字"
+    },
+    "noServersFound": "未找到服务器",
+    "@noServersFound": {
+        "description": "没有服务器时的空状态"
+    },
+    "noServersMatchSearch": "没有服务器符合你的搜索",
+    "@noServersMatchSearch": {
+        "description": "搜索无结果时的空状态"
+    },
+    "serverDetails": "服务器详情",
+    "@serverDetails": {
+        "description": "服务器详情页标题"
+    },
+    "serverNotFound": "未找到服务器",
+    "@serverNotFound": {
+        "description": "找不到服务器时显示"
+    },
+    "map": "地图",
+    "@map": {
+        "description": "地图标签"
+    },
+    "population": "人数",
+    "@population": {
+        "description": "服务器人数标签"
+    },
+    "type": "类型",
+    "@type": {
+        "description": "服务器类型标签"
+    },
+    "official": "官方",
+    "@official": {
+        "description": "官方服务器类型"
+    },
+    "unofficial": "非官方",
+    "@unofficial": {
+        "description": "非官方服务器类型"
+    },
+    "addToFavorites": "添加到收藏",
+    "@addToFavorites": {
+        "description": "添加收藏按钮文字"
+    },
+    "removeFromFavorites": "从收藏中移除",
+    "@removeFromFavorites": {
+        "description": "移除收藏按钮文字"
+    },
+    "addedToFavorites": "已添加到收藏",
+    "@addedToFavorites": {
+        "description": "添加收藏后的提示"
+    },
+    "removedFromFavorites": "已从收藏中移除",
+    "@removedFromFavorites": {
+        "description": "移除收藏后的提示"
+    },
+    "noFavoritesYet": "还没有收藏",
+    "@noFavoritesYet": {
+        "description": "收藏页空状态"
+    },
+    "removeFavorite": "移除收藏",
+    "@removeFavorite": {
+        "description": "移除收藏对话框标题"
+    },
+    "cancel": "取消",
+    "@cancel": {
+        "description": "取消操作"
+    },
+    "remove": "移除",
+    "@remove": {
+        "description": "移除操作"
+    },
+    "apply": "应用",
+    "@apply": {
+        "description": "应用操作"
+    },
+    "removeFavoriteQuestion": "要将“{serverName}”从收藏中移除吗？",
+    "@removeFavoriteQuestion": {
+        "description": "移除收藏前的确认问题",
+        "placeholders": {
+            "serverName": {
+                "type": "String"
+            }
+        }
+    },
+    "removedServerFromFavorites": "{serverName} 已从收藏中移除",
+    "@removedServerFromFavorites": {
+        "description": "滑动删除后的提示",
+        "placeholders": {
+            "serverName": {
+                "type": "String"
+            }
+        }
+    },
+    "general": "通用",
+    "@general": {
+        "description": "设置分区标题"
+    },
+    "language": "语言",
+    "@language": {
+        "description": "语言设置标题"
+    },
+    "systemDefault": "系统默认",
+    "@systemDefault": {
+        "description": "语言设置副标题"
+    },
+    "systemLanguage": "系统语言",
+    "@systemLanguage": {
+        "description": "跟随系统语言的选项"
+    },
+    "german": "德语",
+    "@german": {
+        "description": "德语选项"
+    },
+    "english": "英语",
+    "@english": {
+        "description": "英语选项"
+    },
+    "spanish": "西班牙语",
+    "@spanish": {
+        "description": "西班牙语选项"
+    },
+    "chinese": "中文",
+    "@chinese": {
+        "description": "中文选项"
+    },
+    "selectLanguage": "选择语言",
+    "@selectLanguage": {
+        "description": "语言选择对话框标题"
+    },
+    "about": "关于",
+    "@about": {
+        "description": "关于页面标题"
+    },
+    "appInformation": "应用信息",
+    "@appInformation": {
+        "description": "关于页面副标题"
+    },
+    "legal": "法律信息",
+    "@legal": {
+        "description": "法律分区标题"
+    },
+    "privacyPolicy": "隐私政策",
+    "@privacyPolicy": {
+        "description": "隐私政策标题"
+    },
+    "howDataIsHandled": "数据如何处理",
+    "@howDataIsHandled": {
+        "description": "隐私政策副标题"
+    },
+    "imprint": "法律声明",
+    "@imprint": {
+        "description": "法律声明标题"
+    },
+    "legalInformation": "法律信息",
+    "@legalInformation": {
+        "description": "法律声明副标题"
+    },
+    "support": "支持",
+    "@support": {
+        "description": "支持标题"
+    },
+    "getHelpAndContactSupport": "获取帮助并联系支持",
+    "@getHelpAndContactSupport": {
+        "description": "支持副标题"
+    },
+    "comingSoon": "{title} 即将推出",
+    "@comingSoon": {
+        "description": "尚未实现功能的提示",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add manual language selection in settings with support for German, English, Spanish and Chinese.

## Changes
- added locale controller with Riverpod
- connected MaterialApp locale to app state
- added language dialog widget
- refactored settings widgets
- added German, English, Spanish and Chinese localization options
- kept system language as default option

Closes #9

## Summary by Sourcery

Füge eine manuelle Sprachauswahl in den Einstellungen hinzu und erweitere die Lokalisierung, um neben den bestehenden Sprachen auch Spanisch und Chinesisch zu unterstützen.

Neue Funktionen:
- Einführung eines Dialogs zur Sprachauswahl, der es Nutzer:innen ermöglicht, System, Deutsch, Englisch, Spanisch oder Chinesisch als App‑Sprache auszuwählen.
- Hinzufügen von spanischen und chinesischen Lokalisierungen und Integration in das Lokalisierungssystem der App.

Verbesserungen:
- Überarbeitung der Einstellungen‑UI in wiederverwendbare Widgets `SettingsSectionHeader` und `SettingsTile` und Zentralisierung des „coming soon“-Snackbar‑Verhaltens.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add manual language selection in settings and extend localization to support Spanish and Chinese alongside existing languages.

New Features:
- Introduce a language selection dialog allowing users to choose system, German, English, Spanish, or Chinese as the app language.
- Add Spanish and Chinese localizations and integrate them into the app's localization system.

Enhancements:
- Refactor settings UI into reusable SettingsSectionHeader and SettingsTile widgets and centralize the "coming soon" snackbar behavior.

</details>

Neue Funktionen:
- Dialog zur Sprachauswahl einführen, der es Benutzer:innen ermöglicht, System, Deutsch, Englisch, Spanisch oder Chinesisch als App-Sprache zu wählen.
- Spanische und chinesische Lokalisierungen hinzufügen und zusammen mit den bestehenden Sprachen in das Lokalisierungssystem integrieren.

Verbesserungen:
- UI-Elemente der Einstellungen in wiederverwendbare Widgets `SettingsSectionHeader` und `SettingsTile` auslagern und das „Coming soon“-Snackbar-Verhalten zentralisieren.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Füge eine manuelle Sprachauswahl in den Einstellungen hinzu und erweitere die Lokalisierung, um neben den bestehenden Sprachen auch Spanisch und Chinesisch zu unterstützen.

Neue Funktionen:
- Einführung eines Dialogs zur Sprachauswahl, der es Nutzer:innen ermöglicht, System, Deutsch, Englisch, Spanisch oder Chinesisch als App‑Sprache auszuwählen.
- Hinzufügen von spanischen und chinesischen Lokalisierungen und Integration in das Lokalisierungssystem der App.

Verbesserungen:
- Überarbeitung der Einstellungen‑UI in wiederverwendbare Widgets `SettingsSectionHeader` und `SettingsTile` und Zentralisierung des „coming soon“-Snackbar‑Verhaltens.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add manual language selection in settings and extend localization to support Spanish and Chinese alongside existing languages.

New Features:
- Introduce a language selection dialog allowing users to choose system, German, English, Spanish, or Chinese as the app language.
- Add Spanish and Chinese localizations and integrate them into the app's localization system.

Enhancements:
- Refactor settings UI into reusable SettingsSectionHeader and SettingsTile widgets and centralize the "coming soon" snackbar behavior.

</details>

</details>