### PR TITLE
fix(auth): remove duplicate FirebaseAuthException catch in sign up co…

### DIFF
--- a/lib/features/auth/presentation/controllers/sign_up_controller.dart
+++ b/lib/features/auth/presentation/controllers/sign_up_controller.dart
@@ -58,19 +58,8 @@ class SignUpController {
         email: email.trim(),
         password: password,
       );
-      return null;
-    } on FirebaseAuthException catch (error, stackTrace) {
-      AppLogger.warning(
-        'SignUpController',
-        'FirebaseAuthException during sign-up: ${error.code}',
-      );
 
-      AppLogger.error(
-        'SignUpController',
-        'Sign-up failed with FirebaseAuthException.',
-        error: error,
-        stackTrace: stackTrace,
-      );
+      return null;
     } on FirebaseAuthException catch (error, stackTrace) {
       AppLogger.warning(
         'SignUpController',


### PR DESCRIPTION
…ntroller

## Summary by Sourcery

Bugfixes:
- Verhindert die doppelte Behandlung von `FirebaseAuthException` während der Registrierung, indem die Verarbeitung in einem einzigen `catch`-Block zusammengefasst wird.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent redundant handling of FirebaseAuthException during sign-up by consolidating to a single catch block.

</details>