### PR TITLE
fix(profile): handle initial missing profile state after sign up

### DIFF
--- a/lib/features/profile/data/repositories/profile_repository.dart
+++ b/lib/features/profile/data/repositories/profile_repository.dart
@@ -32,11 +32,43 @@ class ProfileRepository {
     return _userDoc(user.uid).snapshots().map((doc) {
       final data = doc.data();
       if (data == null) {
-        return null;
+        return _buildFallbackProfile(user);
       }
 
       return AppUserProfile.fromMap(doc.id, data);
     });
+  }
+
+  AppUserProfile _buildFallbackProfile(User user) {
+    final resolvedEmail = (user.email ?? '').trim().toLowerCase();
+    final resolvedUsername = (user.displayName ?? '').trim().isNotEmpty
+        ? user.displayName!.trim()
+        : _usernameFromEmail(resolvedEmail);
+
+    return AppUserProfile(
+      id: user.uid,
+      username: resolvedUsername,
+      usernameLower: resolvedUsername.toLowerCase(),
+      email: resolvedEmail,
+      photoUrl: user.photoURL,
+      favoriteIds: const <String>[],
+      sightingsAccessLevel: 'free',
+      createdAt: null,
+    );
+  }
+
+  String _usernameFromEmail(String email) {
+    final atIndex = email.indexOf('@');
+    if (atIndex <= 0) {
+      return 'Player';
+    }
+
+    final candidate = email.substring(0, atIndex).trim();
+    if (candidate.isEmpty) {
+      return 'Player';
+    }
+
+    return candidate;
   }
 
   Future<String> uploadProfileImage(File file) async {
@@ -54,6 +86,9 @@ class ProfileRepository {
   }) async {
     final user = _currentUser;
     final normalizedUsername = username.trim();
+    final normalizedEmail = currentProfile.email.trim().isNotEmpty
+        ? currentProfile.email.trim().toLowerCase()
+        : (user.email ?? '').trim().toLowerCase();
     final resolvedPhotoUrl = newPhotoUrl ?? currentProfile.photoUrl;
 
     await user.updateDisplayName(normalizedUsername);
@@ -62,12 +97,16 @@ class ProfileRepository {
       await user.updatePhotoURL(resolvedPhotoUrl);
     }
 
-    await _userDoc(user.uid).update({
+    await _userDoc(user.uid).set({
       'username': normalizedUsername,
       'usernameLower': normalizedUsername.toLowerCase(),
+      'email': normalizedEmail,
       'photoUrl': resolvedPhotoUrl,
+      'favoriteIds': currentProfile.favoriteIds,
+      'sightingsAccessLevel': currentProfile.sightingsAccessLevel,
+      'createdAt': currentProfile.createdAt ?? FieldValue.serverTimestamp(),
       'updatedAt': FieldValue.serverTimestamp(),
-    });
+    }, SetOptions(merge: true));
   }
 
   Future<void> deleteAccount({

--- a/lib/features/profile/presentation/controllers/profile_form_controller.dart
+++ b/lib/features/profile/presentation/controllers/profile_form_controller.dart
@@ -17,7 +17,7 @@ class ProfileFormController extends ChangeNotifier {
   final TextEditingController usernameController = TextEditingController();
 
   File? _selectedImageFile;
-  String? _hydratedProfileId;
+  String? _hydratedProfileSignature;
   bool _isSaving = false;
   bool _isDeleting = false;
 
@@ -26,10 +26,16 @@ class ProfileFormController extends ChangeNotifier {
   bool get isDeleting => _isDeleting;
 
   void hydrate(AppUserProfile profile) {
-    if (_hydratedProfileId == profile.id) return;
+    final signature =
+        '${profile.id}|${profile.username}|${profile.photoUrl ?? ''}|'
+        '${profile.favoriteIds.length}|${profile.sightingsAccessLevel}';
+
+    if (_hydratedProfileSignature == signature) {
+      return;
+    }
 
     usernameController.text = profile.username;
-    _hydratedProfileId = profile.id;
+    _hydratedProfileSignature = signature;
   }
 
   ImageProvider<Object>? resolveAvatarImage(String? profilePhotoUrl) {

--- a/lib/features/profile/presentation/providers/profile_view_model_provider.dart
+++ b/lib/features/profile/presentation/providers/profile_view_model_provider.dart
@@ -10,20 +10,16 @@ final profileViewModelProvider = Provider<ProfileViewModel>((ref) {
   final profileAsync = ref.watch(profileProvider);
   final formController = ref.watch(profileFormControllerProvider);
 
-  final profile = profileAsync.valueOrNull;
-
-  if (profile != null) {
-    ref.read(profileFormControllerProvider).hydrate(profile);
-  }
-
   return ProfileViewModel(
-    profile: profile,
+    profile: profileAsync.valueOrNull,
     isLoading: profileAsync.isLoading,
     hasError: profileAsync.hasError,
     isSaving: formController.isSaving,
     isDeleting: formController.isDeleting,
     usernameController: formController.usernameController,
-    avatarImage: formController.resolveAvatarImage(profile?.photoUrl),
+    avatarImage: formController.resolveAvatarImage(
+      profileAsync.valueOrNull?.photoUrl,
+    ),
   );
 });
 

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -21,13 +21,17 @@ class ProfileScreen extends ConsumerWidget {
             return const Center(child: CircularProgressIndicator());
           }
 
-          if (viewModel.hasError || !viewModel.hasProfile) {
+          if (viewModel.hasError) {
             return Center(
               child: Padding(
                 padding: const EdgeInsets.all(24),
                 child: Text(context.l10n.profileLoadError),
               ),
             );
+          }
+
+          if (!viewModel.hasProfile) {
+            return const Center(child: CircularProgressIndicator());
           }
 
           return ProfileLoadedView(

--- a/lib/features/profile/presentation/widgets/profile_loaded_view.dart
+++ b/lib/features/profile/presentation/widgets/profile_loaded_view.dart
@@ -1,8 +1,6 @@
 // features/profile/presentation/widgets/profile_loaded_view.dart
 import 'package:asa_server_eye/core/extensions/context_l10n.dart';
-import 'package:asa_server_eye/core/presentation/widgets/app_action_button.dart';
 import 'package:asa_server_eye/features/auth/presentation/providers/auth_repository_provider.dart';
-import 'package:asa_server_eye/features/subscriptions/presentation/utils/premium_navigation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -13,7 +11,7 @@ import 'profile_action_buttons.dart';
 import 'profile_avatar_section.dart';
 import 'profile_info_card.dart';
 
-class ProfileLoadedView extends ConsumerWidget {
+class ProfileLoadedView extends ConsumerStatefulWidget {
   const ProfileLoadedView({
     super.key,
     required this.profile,
@@ -29,23 +27,43 @@ class ProfileLoadedView extends ConsumerWidget {
   final bool isDeleting;
   final TextEditingController usernameController;
 
-  bool get _isPremiumOrAdmin =>
-      profile.sightingsAccessLevel == 'premium' ||
-      profile.sightingsAccessLevel == 'admin';
+  @override
+  ConsumerState<ProfileLoadedView> createState() => _ProfileLoadedViewState();
+}
+
+class _ProfileLoadedViewState extends ConsumerState<ProfileLoadedView> {
+  @override
+  void initState() {
+    super.initState();
+    _hydrate();
+  }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  void didUpdateWidget(covariant ProfileLoadedView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.profile != widget.profile) {
+      _hydrate();
+    }
+  }
+
+  void _hydrate() {
+    ref.read(profileFormControllerProvider).hydrate(widget.profile);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
         ProfileAvatarSection(
-          avatarImage: avatarImage,
-          isSaving: isSaving,
+          avatarImage: widget.avatarImage,
+          isSaving: widget.isSaving,
           onEditTap: () => ref.read(profileFormControllerProvider).pickImage(),
         ),
         const SizedBox(height: 24),
         TextField(
-          controller: usernameController,
+          controller: widget.usernameController,
           decoration: InputDecoration(
             labelText: context.l10n.username,
             prefixIcon: const Icon(Icons.person_outline_rounded),
@@ -54,54 +72,18 @@ class ProfileLoadedView extends ConsumerWidget {
         const SizedBox(height: 16),
         ProfileInfoCard(
           emailLabel: context.l10n.email,
-          email: profile.email,
+          email: widget.profile.email,
           accessLevelLabel: context.l10n.accessLevel,
-          accessLevel: profile.sightingsAccessLevel,
+          accessLevel: widget.profile.sightingsAccessLevel,
           favoritesLabel: context.l10n.favorites,
           favoritesCountText: context.l10n.savedFavoritesCount(
-            profile.favoriteIds.length,
-          ),
-        ),
-        const SizedBox(height: 16),
-        Card(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  _isPremiumOrAdmin
-                      ? context.l10n.premiumActiveTitle
-                      : context.l10n.premiumUpgradeTitle,
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  _isPremiumOrAdmin
-                      ? context.l10n.premiumActiveDescription
-                      : context.l10n.premiumUpgradeDescription,
-                ),
-                const SizedBox(height: 12),
-                AppActionButton(
-                  label: _isPremiumOrAdmin
-                      ? context.l10n.managePremium
-                      : context.l10n.unlockPremium,
-                  isLoading: false,
-                  variant: _isPremiumOrAdmin
-                      ? AppActionButtonVariant.secondary
-                      : AppActionButtonVariant.primary,
-                  onPressed: () async {
-                    await PremiumNavigation.open(context);
-                  },
-                ),
-              ],
-            ),
+            widget.profile.favoriteIds.length,
           ),
         ),
         const SizedBox(height: 24),
         ProfileActionButtons(
-          isSaving: isSaving,
-          isDeleting: isDeleting,
+          isSaving: widget.isSaving,
+          isDeleting: widget.isDeleting,
           isSigningOut: false,
           saveLabel: context.l10n.save,
           signOutLabel: context.l10n.signOut,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: ARK SA Server Eye – real time server population tracker for ARK S
 
 publish_to: "none"
 
-version: 0.1.7+7
+version: 0.1.4+4
 
 environment:
   sdk: ^3.11.1


### PR DESCRIPTION
## Summary
Fixes the profile flow directly after account creation.

## Changes
- handles temporarily missing profile documents safely
- avoids treating the initial missing profile as an error
- improves initial profile loading behavior

## Validation
- flutter analyze passes
- profile no longer fails directly after sign up

## Summary by Sourcery

Behandlung anfänglich fehlender oder unvollständiger Profildaten nach der Registrierung und Verbesserung des Hydrationsverhaltens des Profilformulars.

Bug Fixes:
- Fehlende Firestore-Profildokumente als Fallback-Profil statt als Fehler behandeln, um Fehler unmittelbar nach der Kontoerstellung zu verhindern.
- Profil-E-Mail und andere Felder beim Speichern zuverlässig normalisieren und persistieren, selbst wenn sie zuvor gefehlt haben.

Enhancements:
- Hydration des Profilformulars in das Profil-View-Widget verschieben und signaturbasierte Änderungs­erkennung verwenden, um nur dann neu zu hydratisieren, wenn profilrelevante Felder geändert werden.
- Einen Ladezustand anzeigen, wenn das Profil noch nicht aufgelöst wurde, anstatt es als Fehler zu behandeln.
- `Firestore set` mit `merge` verwenden, um Profildokumente konsistent zu erstellen oder zu aktualisieren.
- Die Profilansicht vereinfachen, indem die eingebettete Premium-Upsell-Karte aus der geladenen Profilansicht entfernt wird.

Build:
- App-Versionsmetadaten in `pubspec.yaml` anpassen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle initial missing or partial profile data after sign-up and improve profile form hydration behavior.

Bug Fixes:
- Treat missing Firestore profile documents as a fallback profile instead of an error, preventing failures immediately after account creation.
- Normalize and persist profile email and other fields reliably when saving, even if they were previously missing.

Enhancements:
- Move profile form hydration into the profile view widget with signature-based change detection to rehydrate only when profile-relevant fields change.
- Show a loading state when the profile has not yet been resolved instead of treating it as an error.
- Use Firestore set with merge to create or update profile documents consistently.
- Simplify the profile view by removing the embedded premium upsell card from the loaded profile view.

Build:
- Adjust app version metadata in pubspec.yaml.

</details>