### PR TITLE
fix(profile): return to auth root after logout and account deletion

### DIFF
--- a/lib/features/profile/presentation/providers/profile_providers.dart
+++ b/lib/features/profile/presentation/providers/profile_providers.dart
@@ -1,10 +1,17 @@
 // features/profile/presentation/providers/profile_providers.dart
+import 'package:asa_server_eye/features/auth/presentation/providers/current_user_provider.dart';
 import 'package:asa_server_eye/features/profile/presentation/providers/profile_repository_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../domain/app_user_profile.dart';
 
-final profileProvider = StreamProvider<AppUserProfile?>((ref) {
+final profileProvider = StreamProvider.autoDispose<AppUserProfile?>((ref) {
+  final currentUser = ref.watch(currentUserProvider);
+
+  if (currentUser == null) {
+    return Stream.value(null);
+  }
+
   final repository = ref.watch(profileRepositoryProvider);
   return repository.watchProfile();
 });

--- a/lib/features/profile/presentation/providers/profile_view_model_provider.dart
+++ b/lib/features/profile/presentation/providers/profile_view_model_provider.dart
@@ -6,7 +6,7 @@ import '../models/profile_view_model.dart';
 import 'profile_form_controller_provider.dart';
 import 'profile_providers.dart';
 
-final profileViewModelProvider = Provider<ProfileViewModel>((ref) {
+final profileViewModelProvider = Provider.autoDispose<ProfileViewModel>((ref) {
   final profileAsync = ref.watch(profileProvider);
   final formController = ref.watch(profileFormControllerProvider);
 
@@ -23,6 +23,6 @@ final profileViewModelProvider = Provider<ProfileViewModel>((ref) {
   );
 });
 
-final profileViewProfileProvider = Provider<AppUserProfile?>((ref) {
+final profileViewProfileProvider = Provider.autoDispose<AppUserProfile?>((ref) {
   return ref.watch(profileViewModelProvider).profile;
 });

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,5 +1,6 @@
 // features/profile/presentation/screens/profile_screen.dart
 import 'package:asa_server_eye/core/extensions/context_l10n.dart';
+import 'package:asa_server_eye/features/auth/presentation/providers/current_user_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -11,7 +12,12 @@ class ProfileScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final currentUser = ref.watch(currentUserProvider);
     final viewModel = ref.watch(profileViewModelProvider);
+
+    if (currentUser == null) {
+      return const Scaffold(body: SizedBox.shrink());
+    }
 
     return Scaffold(
       appBar: AppBar(title: Text(context.l10n.profile)),

--- a/lib/features/profile/presentation/utils/profile_screen_actions.dart
+++ b/lib/features/profile/presentation/utils/profile_screen_actions.dart
@@ -69,6 +69,14 @@ abstract final class ProfileScreenActions {
         context,
         ProfileMessageMapper.mapDeleteResult(context, result),
       );
+      return;
+    }
+
+    if (result == ProfileDeleteResult.success) {
+      Navigator.of(
+        context,
+        rootNavigator: true,
+      ).popUntil((route) => route.isFirst);
     }
   }
 }

--- a/lib/features/profile/presentation/widgets/profile_loaded_view.dart
+++ b/lib/features/profile/presentation/widgets/profile_loaded_view.dart
@@ -91,6 +91,11 @@ class _ProfileLoadedViewState extends ConsumerState<ProfileLoadedView> {
           deleteHint: context.l10n.deleteAccountHint,
           onSave: () => ProfileScreenActions.save(context: context, ref: ref),
           onSignOut: () async {
+            Navigator.of(
+              context,
+              rootNavigator: true,
+            ).popUntil((route) => route.isFirst);
+
             await ref.read(authRepositoryProvider).signOut();
           },
           onDelete: () =>


### PR DESCRIPTION
## Summary
Fixes profile navigation when signing out or deleting an account.

## Changes
- stops profile stream when no user is signed in
- avoids profile load errors after logout
- returns to auth root after account deletion

## Validation
- flutter analyze passes
- logout no longer leaves the user on profile
- deleting an account returns to login flow

## Summary by Sourcery

Verbessert den Profil-Flow, wenn sich ein Nutzer abmeldet oder sein Konto löscht, um veraltete Profilzustände zu verhindern und zurück zur Authentifizierungs-Root zu navigieren.

Bug Fixes:
- Beende den Profil-Stream und das ViewModel, wenn kein angemeldeter Nutzer vorhanden ist, um Profil-Ladefehler nach dem Logout zu vermeiden.
- Verhindere das Rendern des Profil-Screens, wenn kein aktueller Nutzer existiert, damit Nutzer nach dem Abmelden nicht auf dem Profil bleiben.

Enhancements:
- Navigiere nach Kontolöschung oder Abmeldung zurück zur Root des Auth-/Navigations-Stacks, damit Nutzer korrekt in den Login-Flow zurückkehren.
- Markiere profilbezogene Provider als auto-dispose, um den Zustand aufzuräumen, wenn der Profil-Screen verlassen wird.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve profile flow when a user signs out or deletes their account to prevent stale profile state and navigate back to the authentication root.

Bug Fixes:
- Stop the profile stream and view model when there is no signed-in user to avoid profile load errors after logout.
- Avoid rendering the profile screen when no current user exists, preventing users from remaining on profile after sign-out.

Enhancements:
- Navigate back to the root of the auth/navigation stack after account deletion or sign-out so users correctly return to the login flow.
- Mark profile-related providers as auto-dispose to clean up state when the profile screen is left.

</details>