### PR TITLE
fix(auth): return to auth root after successful sign up

### DIFF
--- a/lib/features/auth/presentation/screens/sign_up_screen.dart
+++ b/lib/features/auth/presentation/screens/sign_up_screen.dart
@@ -1,5 +1,5 @@
 // features/auth/presentation/screens/sign_up_screen.dart
-import 'package:asa_server_eye/core/presentation/widgets/app_action_button.dart';
+import 'package:asa_server_eye/app/presentation/widgets/app_action_button.dart';
 import 'package:asa_server_eye/features/auth/presentation/providers/sign_up_form_controller_provider.dart';
 import 'package:asa_server_eye/features/auth/presentation/widgets/app_gradient_background.dart';
 import 'package:flutter/material.dart';
@@ -88,7 +88,7 @@ class SignUpScreen extends ConsumerWidget {
                               context.l10n.accountCreated,
                             );
 
-                            AuthNavigation.close(context);
+                            AuthNavigation.returnToAuthRoot(context);
                           },
                         ),
                         const SizedBox(height: 8),

--- a/lib/features/auth/presentation/utils/auth_navigation.dart
+++ b/lib/features/auth/presentation/utils/auth_navigation.dart
@@ -11,6 +11,18 @@ abstract final class AuthNavigation {
   }
 
   static void close(BuildContext context) {
-    Navigator.of(context).pop();
+    if (Navigator.of(context).canPop()) {
+      Navigator.of(context).pop();
+    }
+  }
+
+  static void returnToAuthRoot(BuildContext context) {
+    final navigator = Navigator.of(context);
+
+    if (!navigator.canPop()) {
+      return;
+    }
+
+    navigator.popUntil((route) => route.isFirst);
   }
 }


### PR DESCRIPTION
## Summary
Returns to the auth root after successful sign up so AuthGate can switch cleanly to the signed-in app state.

## Changes
- adds a helper to return to the auth root
- uses auth-root navigation after successful sign up instead of a simple pop

## Validation
- flutter analyze passes
- sign-up no longer depends on fragile single-route pop behavior

## Summary by Sourcery

Stellen Sie sicher, dass der Abschluss der Registrierung die Benutzer zur Auth-Root-Route zurückführt, anstatt nur eine einfache Zurück-Navigation zu verwenden, um eine robustere Zustandsverwaltung zu gewährleisten.

Verbesserungen:
- Hinzufügen eines Auth-Navigationshelfers, der sicher zur Auth-Root-Route zurückkehrt und vor nicht-poppbaren Navigator-Zuständen schützt.
- Aktualisierung des Registrierungsablaufs, sodass nach der Kontoerstellung die Auth-Root-Navigation verwendet wird, anstatt sich auf ein einfaches Zurücknavigieren um eine Route zu verlassen.
- Anpassung der Abhängigkeiten des Registrierungsbildschirms, sodass das gemeinsame App-Action-Button-Widget aus der App-Präsentationsebene verwendet wird.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure sign-up completion returns users to the auth root route instead of a simple back navigation for more robust state handling.

Enhancements:
- Add an auth navigation helper to return to the root auth route safely, guarding against non-poppable navigator states.
- Update the sign-up flow to use auth-root navigation after account creation instead of relying on a single-route pop.
- Adjust sign-up screen dependencies to use the shared app action button widget from the app presentation layer.

</details>