### PR TITLE
ci(play): add PR checks and Google Play release workflows

### DIFF
--- a/.github/workflows/deploy-play-internal.yml
+++ b/.github/workflows/deploy-play-internal.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: "17"
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -36,7 +36,7 @@ jobs:
           storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
-          storeFile=app/upload-keystore.jks
+          storeFile=upload-keystore.jks
           EOF
 
       - name: Flutter pub get
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: "3.2"
 
       - name: Install fastlane
         run: gem install fastlane

--- a/.github/workflows/deploy-play-internal.yml
+++ b/.github/workflows/deploy-play-internal.yml
@@ -1,0 +1,72 @@
+name: Deploy to Google Play Internal
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy-internal:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/upload-keystore.jks
+
+      - name: Create key.properties
+        run: |
+          cat <<EOF > android/key.properties
+          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          storeFile=app/upload-keystore.jks
+          EOF
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Build release AAB
+        run: flutter build appbundle --release --build-number=${{ github.run_number }}
+
+      - name: Write Google Play service account
+        run: |
+          cat <<'EOF' > play-service-account.json
+          ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          EOF
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install fastlane
+        run: gem install fastlane
+
+      - name: Upload to Google Play Internal
+        run: |
+          fastlane supply \
+            --aab build/app/outputs/bundle/release/app-release.aab \
+            --json_key play-service-account.json \
+            --package_name com.jchillah.asaservereye \
+            --track internal \
+            --skip_upload_metadata true \
+            --skip_upload_images true \
+            --skip_upload_screenshots true \
+            --release_status completed

--- a/.github/workflows/deploy-play-production.yml
+++ b/.github/workflows/deploy-play-production.yml
@@ -1,0 +1,69 @@
+name: Deploy to Google Play Production
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-production:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/upload-keystore.jks
+
+      - name: Create key.properties
+        run: |
+          cat <<EOF > android/key.properties
+          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          storeFile=app/upload-keystore.jks
+          EOF
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Build release AAB
+        run: flutter build appbundle --release --build-number=${{ github.run_number }}
+
+      - name: Write Google Play service account
+        run: |
+          cat <<'EOF' > play-service-account.json
+          ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          EOF
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install fastlane
+        run: gem install fastlane
+
+      - name: Upload to Google Play Production as draft
+        run: |
+          fastlane supply \
+            --aab build/app/outputs/bundle/release/app-release.aab \
+            --json_key play-service-account.json \
+            --package_name com.jchillah.asaservereye \
+            --track production \
+            --skip_upload_metadata true \
+            --skip_upload_images true \
+            --skip_upload_screenshots true \
+            --release_status draft

--- a/.github/workflows/deploy-play-production.yml
+++ b/.github/workflows/deploy-play-production.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: "17"
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -33,7 +33,7 @@ jobs:
           storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
-          storeFile=app/upload-keystore.jks
+          storeFile=upload-keystore.jks
           EOF
 
       - name: Flutter pub get
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: "3.2"
 
       - name: Install fastlane
         run: gem install fastlane

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,44 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  flutter-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Flutter analyze
+        run: flutter analyze
+
+      - name: Flutter test
+        run: flutter test
+
+      - name: Build release AAB
+        run: flutter build appbundle --release --build-number=${{ github.run_number }}
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-aab
+          path: build/app/outputs/bundle/release/app-release.aab

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,4 +1,4 @@
 storePassword=CHANGE_ME
 keyPassword=CHANGE_ME
 keyAlias=CHANGE_ME
-storeFile=app/upload-keystore.jks
+storeFile=upload-keystore.jks

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,0 +1,4 @@
+storePassword=CHANGE_ME
+keyPassword=CHANGE_ME
+keyAlias=CHANGE_ME
+storeFile=app/upload-keystore.jks


### PR DESCRIPTION
## Summary
Adds GitHub Actions workflows for PR validation, automatic Google Play internal releases, and manual production releases.

## Changes
- adds `pr-check.yml` for Flutter analyze, tests, and Android AAB artifact generation on pull requests
- adds `deploy-play-internal.yml` to automatically upload signed Android builds to the Google Play Internal track
- adds `deploy-play-production.yml` for manual production releases
- adds `android/key.properties.example` to document the expected local and CI signing setup
- fixes the CI signing path so the release keystore is resolved correctly

## Why
This sets up a safer release flow:
- pull requests are validated automatically
- merges to `main` can go to Internal Testing automatically
- Production remains manual for safety

## Required setup
Before the workflows can release to Google Play, the following GitHub Actions secrets must be configured:
- `PLAY_SERVICE_ACCOUNT_JSON`
- `ANDROID_KEYSTORE_BASE64`
- `ANDROID_KEYSTORE_PASSWORD`
- `ANDROID_KEY_ALIAS`
- `ANDROID_KEY_PASSWORD`

## Validation
- local signed Android AAB build succeeds
- CI workflow files added for PR checks and Play Store release automation

## Summary by Sourcery

CI-Workflows für PR-Validierung und Google-Play-Releases hinzufügen.

Build:
- Einführung eines PR-Check-Workflows, der Flutter-Analyse, Tests ausführt und ein Android App Bundle baut und dieses als Build-Artefakt veröffentlicht.
- Hinzufügen eines automatisierten Workflows zum Erstellen und Bereitstellen signierter Android App Bundles auf den Google Play Internal Track bei Pushes auf den Branch `main`.
- Hinzufügen eines manuellen Workflows zum Erstellen und Bereitstellen signierter Android App Bundles auf den Google Play Production Track als Entwurfs-Releases.
- Hinzufügen einer Beispiel-Android-`key.properties`-Datei, um die erwartete Keystore-Konfiguration für lokale Builds und CI-Builds zu dokumentieren.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add CI workflows for PR validation and Google Play releases.

Build:
- Introduce a PR check workflow that runs Flutter analysis, tests, and builds an Android app bundle, publishing it as a build artifact.
- Add an automated workflow to build and deploy signed Android app bundles to the Google Play Internal track on pushes to main.
- Add a manual workflow to build and deploy signed Android app bundles to the Google Play Production track as draft releases.
- Add an example Android key.properties file to document expected keystore configuration for local and CI builds.

</details>