### PR TITLE
feat(alerts): add alert rule model and Firestore persistence

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -165,6 +165,83 @@ service cloud.firestore {
       allow delete: if isSignedIn() && request.auth.uid == uid;
     }
 
+    // -------- USER ALERT RULES --------
+    match /users/{uid}/alert_rules/{ruleId} {
+
+      allow read: if isSignedIn() && request.auth.uid == uid;
+
+      allow create: if isSignedIn()
+        && request.auth.uid == uid
+        && request.resource.data.keys().hasOnly([
+          'userId',
+          'serverId',
+          'serverName',
+          'mapName',
+          'ruleType',
+          'isEnabled',
+          'threshold',
+          'createdAt',
+          'updatedAt',
+          'lastTriggeredAt'
+        ])
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.serverId is string
+        && request.resource.data.serverId.size() > 0
+        && request.resource.data.serverName is string
+        && request.resource.data.serverName.size() > 0
+        && request.resource.data.mapName is string
+        && request.resource.data.mapName.size() > 0
+        && request.resource.data.ruleType in [
+          'population_increased',
+          'population_decreased',
+          'crossed_above_threshold',
+          'crossed_below_threshold',
+          'server_online',
+          'server_offline'
+        ]
+        && request.resource.data.isEnabled is bool
+        && (request.resource.data.threshold == null || request.resource.data.threshold is int)
+        && request.resource.data.createdAt == request.time
+        && request.resource.data.updatedAt == request.time
+        && request.resource.data.lastTriggeredAt == null;
+
+      allow update: if isSignedIn()
+        && request.auth.uid == uid
+        && request.resource.data.keys().hasOnly([
+          'userId',
+          'serverId',
+          'serverName',
+          'mapName',
+          'ruleType',
+          'isEnabled',
+          'threshold',
+          'createdAt',
+          'updatedAt',
+          'lastTriggeredAt'
+        ])
+        && request.resource.data.userId == resource.data.userId
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.serverId == resource.data.serverId
+        && request.resource.data.serverName is string
+        && request.resource.data.serverName.size() > 0
+        && request.resource.data.mapName is string
+        && request.resource.data.mapName.size() > 0
+        && request.resource.data.ruleType in [
+          'population_increased',
+          'population_decreased',
+          'crossed_above_threshold',
+          'crossed_below_threshold',
+          'server_online',
+          'server_offline'
+        ]
+        && request.resource.data.isEnabled is bool
+        && (request.resource.data.threshold == null || request.resource.data.threshold is int)
+        && request.resource.data.createdAt == resource.data.createdAt
+        && request.resource.data.updatedAt == request.time;
+
+      allow delete: if isSignedIn() && request.auth.uid == uid;
+    }
+
     // -------- PLAYER SIGHTINGS --------
     match /player_sightings/{sightingId} {
 

--- a/lib/features/alerts/data/dtos/alert_rule_dto.dart
+++ b/lib/features/alerts/data/dtos/alert_rule_dto.dart
@@ -1,0 +1,92 @@
+// features/alerts/data/dtos/alert_rule_dto.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../domain/entities/alert_rule.dart';
+import '../../domain/entities/alert_rule_type.dart';
+
+class AlertRuleDto {
+  const AlertRuleDto({
+    required this.userId,
+    required this.serverId,
+    required this.serverName,
+    required this.mapName,
+    required this.ruleType,
+    required this.isEnabled,
+    required this.threshold,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.lastTriggeredAt,
+  });
+
+  final String userId;
+  final String serverId;
+  final String serverName;
+  final String mapName;
+  final String ruleType;
+  final bool isEnabled;
+  final int? threshold;
+  final Timestamp? createdAt;
+  final Timestamp? updatedAt;
+  final Timestamp? lastTriggeredAt;
+
+  factory AlertRuleDto.fromFirestore(Map<String, dynamic> json) {
+    return AlertRuleDto(
+      userId: json['userId'] as String? ?? '',
+      serverId: json['serverId'] as String? ?? '',
+      serverName: json['serverName'] as String? ?? '',
+      mapName: json['mapName'] as String? ?? '',
+      ruleType: json['ruleType'] as String? ?? '',
+      isEnabled: json['isEnabled'] as bool? ?? true,
+      threshold: json['threshold'] as int?,
+      createdAt: json['createdAt'] as Timestamp?,
+      updatedAt: json['updatedAt'] as Timestamp?,
+      lastTriggeredAt: json['lastTriggeredAt'] as Timestamp?,
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'userId': userId,
+      'serverId': serverId,
+      'serverName': serverName,
+      'mapName': mapName,
+      'ruleType': ruleType,
+      'isEnabled': isEnabled,
+      'threshold': threshold,
+      'createdAt': createdAt,
+      'updatedAt': updatedAt,
+      'lastTriggeredAt': lastTriggeredAt,
+    };
+  }
+
+  AlertRule toDomain(String id) {
+    return AlertRule(
+      id: id,
+      userId: userId,
+      serverId: serverId,
+      serverName: serverName,
+      mapName: mapName,
+      ruleType: AlertRuleTypeX.fromFirestore(ruleType),
+      isEnabled: isEnabled,
+      threshold: threshold,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      lastTriggeredAt: lastTriggeredAt,
+    );
+  }
+
+  static AlertRuleDto fromDomain(AlertRule rule) {
+    return AlertRuleDto(
+      userId: rule.userId,
+      serverId: rule.serverId,
+      serverName: rule.serverName,
+      mapName: rule.mapName,
+      ruleType: rule.ruleType.firestoreValue,
+      isEnabled: rule.isEnabled,
+      threshold: rule.threshold,
+      createdAt: rule.createdAt,
+      updatedAt: rule.updatedAt,
+      lastTriggeredAt: rule.lastTriggeredAt,
+    );
+  }
+}

--- a/lib/features/alerts/data/dtos/alert_rule_dto.dart
+++ b/lib/features/alerts/data/dtos/alert_rule_dto.dart
@@ -31,16 +31,60 @@ class AlertRuleDto {
 
   factory AlertRuleDto.fromFirestore(Map<String, dynamic> json) {
     return AlertRuleDto(
-      userId: json['userId'] as String? ?? '',
-      serverId: json['serverId'] as String? ?? '',
-      serverName: json['serverName'] as String? ?? '',
-      mapName: json['mapName'] as String? ?? '',
-      ruleType: json['ruleType'] as String? ?? '',
-      isEnabled: json['isEnabled'] as bool? ?? true,
-      threshold: json['threshold'] as int?,
-      createdAt: json['createdAt'] as Timestamp?,
-      updatedAt: json['updatedAt'] as Timestamp?,
-      lastTriggeredAt: json['lastTriggeredAt'] as Timestamp?,
+      userId: _requireNonEmptyString(json, 'userId'),
+      serverId: _requireNonEmptyString(json, 'serverId'),
+      serverName: _requireNonEmptyString(json, 'serverName'),
+      mapName: _requireNonEmptyString(json, 'mapName'),
+      ruleType: _requireNonEmptyString(json, 'ruleType'),
+      isEnabled: _requireBool(json, 'isEnabled'),
+      threshold: _parseThreshold(json['threshold']),
+      createdAt: _readTimestamp(json, 'createdAt'),
+      updatedAt: _readTimestamp(json, 'updatedAt'),
+      lastTriggeredAt: _readTimestamp(json, 'lastTriggeredAt'),
+    );
+  }
+
+  static String _requireNonEmptyString(Map<String, dynamic> json, String key) {
+    final value = json[key];
+    if (value is! String || value.trim().isEmpty) {
+      throw StateError('AlertRuleDto.fromFirestore: invalid or missing "$key"');
+    }
+    return value;
+  }
+
+  static bool _requireBool(Map<String, dynamic> json, String key) {
+    final value = json[key];
+    if (value is! bool) {
+      throw StateError('AlertRuleDto.fromFirestore: invalid or missing "$key"');
+    }
+    return value;
+  }
+
+  static int? _parseThreshold(Object? value) {
+    if (value == null) {
+      return null;
+    }
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    throw StateError(
+      'AlertRuleDto.fromFirestore: invalid "threshold" value: $value',
+    );
+  }
+
+  static Timestamp? _readTimestamp(Map<String, dynamic> json, String key) {
+    final value = json[key];
+    if (value == null) {
+      return null;
+    }
+    if (value is Timestamp) {
+      return value;
+    }
+    throw StateError(
+      'AlertRuleDto.fromFirestore: invalid "$key" value: $value',
     );
   }
 
@@ -60,18 +104,23 @@ class AlertRuleDto {
   }
 
   AlertRule toDomain(String id) {
+    final parsedRuleType = AlertRuleTypeX.tryFromFirestore(ruleType);
+    if (parsedRuleType == null) {
+      throw StateError('AlertRuleDto.toDomain: unknown ruleType "$ruleType"');
+    }
+
     return AlertRule(
       id: id,
       userId: userId,
       serverId: serverId,
       serverName: serverName,
       mapName: mapName,
-      ruleType: AlertRuleTypeX.fromFirestore(ruleType),
+      ruleType: parsedRuleType,
       isEnabled: isEnabled,
       threshold: threshold,
-      createdAt: createdAt,
-      updatedAt: updatedAt,
-      lastTriggeredAt: lastTriggeredAt,
+      createdAt: createdAt?.toDate(),
+      updatedAt: updatedAt?.toDate(),
+      lastTriggeredAt: lastTriggeredAt?.toDate(),
     );
   }
 
@@ -84,9 +133,15 @@ class AlertRuleDto {
       ruleType: rule.ruleType.firestoreValue,
       isEnabled: rule.isEnabled,
       threshold: rule.threshold,
-      createdAt: rule.createdAt,
-      updatedAt: rule.updatedAt,
-      lastTriggeredAt: rule.lastTriggeredAt,
+      createdAt: rule.createdAt == null
+          ? null
+          : Timestamp.fromDate(rule.createdAt!),
+      updatedAt: rule.updatedAt == null
+          ? null
+          : Timestamp.fromDate(rule.updatedAt!),
+      lastTriggeredAt: rule.lastTriggeredAt == null
+          ? null
+          : Timestamp.fromDate(rule.lastTriggeredAt!),
     );
   }
 }

--- a/lib/features/alerts/data/repositories/firestore_alert_rules_repository.dart
+++ b/lib/features/alerts/data/repositories/firestore_alert_rules_repository.dart
@@ -1,4 +1,6 @@
 // features/alerts/data/repositories/firestore_alert_rules_repository.dart
+import 'dart:developer' as developer;
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../../domain/entities/alert_rule.dart';
@@ -14,19 +16,31 @@ class FirestoreAlertRulesRepository implements AlertRulesRepository {
     return _firestore.collection('users').doc(userId).collection('alert_rules');
   }
 
+  List<AlertRule> _mapRules(QuerySnapshot<Map<String, dynamic>> snapshot) {
+    final rules = <AlertRule>[];
+
+    for (final doc in snapshot.docs) {
+      try {
+        final rule = AlertRuleDto.fromFirestore(doc.data()).toDomain(doc.id);
+        rules.add(rule);
+      } catch (error, stackTrace) {
+        developer.log(
+          'Skipping invalid alert rule document: ${doc.id}',
+          name: 'FirestoreAlertRulesRepository',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+
+    return rules;
+  }
+
   @override
   Stream<List<AlertRule>> watchRules(String userId) {
-    return _rulesCollection(userId)
-        .orderBy('createdAt', descending: true)
-        .snapshots()
-        .map(
-          (snapshot) => snapshot.docs
-              .map(
-                (doc) =>
-                    AlertRuleDto.fromFirestore(doc.data()).toDomain(doc.id),
-              )
-              .toList(),
-        );
+    return _rulesCollection(
+      userId,
+    ).orderBy('createdAt', descending: true).snapshots().map(_mapRules);
   }
 
   @override
@@ -38,14 +52,7 @@ class FirestoreAlertRulesRepository implements AlertRulesRepository {
         .where('serverId', isEqualTo: serverId)
         .orderBy('createdAt', descending: true)
         .snapshots()
-        .map(
-          (snapshot) => snapshot.docs
-              .map(
-                (doc) =>
-                    AlertRuleDto.fromFirestore(doc.data()).toDomain(doc.id),
-              )
-              .toList(),
-        );
+        .map(_mapRules);
   }
 
   @override

--- a/lib/features/alerts/data/repositories/firestore_alert_rules_repository.dart
+++ b/lib/features/alerts/data/repositories/firestore_alert_rules_repository.dart
@@ -1,0 +1,94 @@
+// features/alerts/data/repositories/firestore_alert_rules_repository.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../domain/entities/alert_rule.dart';
+import '../../domain/repositories/alert_rules_repository.dart';
+import '../dtos/alert_rule_dto.dart';
+
+class FirestoreAlertRulesRepository implements AlertRulesRepository {
+  FirestoreAlertRulesRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _rulesCollection(String userId) {
+    return _firestore.collection('users').doc(userId).collection('alert_rules');
+  }
+
+  @override
+  Stream<List<AlertRule>> watchRules(String userId) {
+    return _rulesCollection(userId)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map(
+          (snapshot) => snapshot.docs
+              .map(
+                (doc) =>
+                    AlertRuleDto.fromFirestore(doc.data()).toDomain(doc.id),
+              )
+              .toList(),
+        );
+  }
+
+  @override
+  Stream<List<AlertRule>> watchRulesForServer({
+    required String userId,
+    required String serverId,
+  }) {
+    return _rulesCollection(userId)
+        .where('serverId', isEqualTo: serverId)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map(
+          (snapshot) => snapshot.docs
+              .map(
+                (doc) =>
+                    AlertRuleDto.fromFirestore(doc.data()).toDomain(doc.id),
+              )
+              .toList(),
+        );
+  }
+
+  @override
+  Future<void> createRule(AlertRule rule) async {
+    final docRef = _rulesCollection(rule.userId).doc();
+    final dto = AlertRuleDto.fromDomain(
+      rule.copyWith(id: docRef.id, createdAt: null, updatedAt: null),
+    );
+
+    await docRef.set({
+      ...dto.toFirestore(),
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  @override
+  Future<void> updateRule(AlertRule rule) async {
+    final dto = AlertRuleDto.fromDomain(rule);
+
+    await _rulesCollection(rule.userId).doc(rule.id).update({
+      ...dto.toFirestore(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  @override
+  Future<void> deleteRule({
+    required String userId,
+    required String ruleId,
+  }) async {
+    await _rulesCollection(userId).doc(ruleId).delete();
+  }
+
+  @override
+  Future<void> setRuleEnabled({
+    required String userId,
+    required String ruleId,
+    required bool isEnabled,
+  }) async {
+    await _rulesCollection(userId).doc(ruleId).update({
+      'isEnabled': isEnabled,
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+}

--- a/lib/features/alerts/domain/entities/alert_rule.dart
+++ b/lib/features/alerts/domain/entities/alert_rule.dart
@@ -1,6 +1,4 @@
 // features/alerts/domain/entities/alert_rule.dart
-import 'package:cloud_firestore/cloud_firestore.dart';
-
 import 'alert_rule_type.dart';
 
 class AlertRule {
@@ -18,6 +16,8 @@ class AlertRule {
     this.lastTriggeredAt,
   });
 
+  static const Object _unset = Object();
+
   final String id;
   final String userId;
   final String serverId;
@@ -26,9 +26,9 @@ class AlertRule {
   final AlertRuleType ruleType;
   final bool isEnabled;
   final int? threshold;
-  final Timestamp? createdAt;
-  final Timestamp? updatedAt;
-  final Timestamp? lastTriggeredAt;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? lastTriggeredAt;
 
   AlertRule copyWith({
     String? id,
@@ -38,10 +38,10 @@ class AlertRule {
     String? mapName,
     AlertRuleType? ruleType,
     bool? isEnabled,
-    int? threshold,
-    Timestamp? createdAt,
-    Timestamp? updatedAt,
-    Timestamp? lastTriggeredAt,
+    Object? threshold = _unset,
+    Object? createdAt = _unset,
+    Object? updatedAt = _unset,
+    Object? lastTriggeredAt = _unset,
   }) {
     return AlertRule(
       id: id ?? this.id,
@@ -51,10 +51,18 @@ class AlertRule {
       mapName: mapName ?? this.mapName,
       ruleType: ruleType ?? this.ruleType,
       isEnabled: isEnabled ?? this.isEnabled,
-      threshold: threshold ?? this.threshold,
-      createdAt: createdAt ?? this.createdAt,
-      updatedAt: updatedAt ?? this.updatedAt,
-      lastTriggeredAt: lastTriggeredAt ?? this.lastTriggeredAt,
+      threshold: identical(threshold, _unset)
+          ? this.threshold
+          : threshold as int?,
+      createdAt: identical(createdAt, _unset)
+          ? this.createdAt
+          : createdAt as DateTime?,
+      updatedAt: identical(updatedAt, _unset)
+          ? this.updatedAt
+          : updatedAt as DateTime?,
+      lastTriggeredAt: identical(lastTriggeredAt, _unset)
+          ? this.lastTriggeredAt
+          : lastTriggeredAt as DateTime?,
     );
   }
 

--- a/lib/features/alerts/domain/entities/alert_rule.dart
+++ b/lib/features/alerts/domain/entities/alert_rule.dart
@@ -1,0 +1,64 @@
+// features/alerts/domain/entities/alert_rule.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'alert_rule_type.dart';
+
+class AlertRule {
+  const AlertRule({
+    required this.id,
+    required this.userId,
+    required this.serverId,
+    required this.serverName,
+    required this.mapName,
+    required this.ruleType,
+    required this.isEnabled,
+    required this.createdAt,
+    required this.updatedAt,
+    this.threshold,
+    this.lastTriggeredAt,
+  });
+
+  final String id;
+  final String userId;
+  final String serverId;
+  final String serverName;
+  final String mapName;
+  final AlertRuleType ruleType;
+  final bool isEnabled;
+  final int? threshold;
+  final Timestamp? createdAt;
+  final Timestamp? updatedAt;
+  final Timestamp? lastTriggeredAt;
+
+  AlertRule copyWith({
+    String? id,
+    String? userId,
+    String? serverId,
+    String? serverName,
+    String? mapName,
+    AlertRuleType? ruleType,
+    bool? isEnabled,
+    int? threshold,
+    Timestamp? createdAt,
+    Timestamp? updatedAt,
+    Timestamp? lastTriggeredAt,
+  }) {
+    return AlertRule(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      serverId: serverId ?? this.serverId,
+      serverName: serverName ?? this.serverName,
+      mapName: mapName ?? this.mapName,
+      ruleType: ruleType ?? this.ruleType,
+      isEnabled: isEnabled ?? this.isEnabled,
+      threshold: threshold ?? this.threshold,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      lastTriggeredAt: lastTriggeredAt ?? this.lastTriggeredAt,
+    );
+  }
+
+  bool get requiresThreshold =>
+      ruleType == AlertRuleType.crossedAboveThreshold ||
+      ruleType == AlertRuleType.crossedBelowThreshold;
+}

--- a/lib/features/alerts/domain/entities/alert_rule_type.dart
+++ b/lib/features/alerts/domain/entities/alert_rule_type.dart
@@ -26,7 +26,7 @@ extension AlertRuleTypeX on AlertRuleType {
     }
   }
 
-  static AlertRuleType fromFirestore(String value) {
+  static AlertRuleType? tryFromFirestore(String? value) {
     switch (value) {
       case 'population_increased':
         return AlertRuleType.populationIncreased;
@@ -41,7 +41,7 @@ extension AlertRuleTypeX on AlertRuleType {
       case 'server_offline':
         return AlertRuleType.serverOffline;
       default:
-        throw ArgumentError('Unknown AlertRuleType value: $value');
+        return null;
     }
   }
 }

--- a/lib/features/alerts/domain/entities/alert_rule_type.dart
+++ b/lib/features/alerts/domain/entities/alert_rule_type.dart
@@ -1,0 +1,47 @@
+// features/alerts/domain/entities/alert_rule_type.dart
+enum AlertRuleType {
+  populationIncreased,
+  populationDecreased,
+  crossedAboveThreshold,
+  crossedBelowThreshold,
+  serverOnline,
+  serverOffline,
+}
+
+extension AlertRuleTypeX on AlertRuleType {
+  String get firestoreValue {
+    switch (this) {
+      case AlertRuleType.populationIncreased:
+        return 'population_increased';
+      case AlertRuleType.populationDecreased:
+        return 'population_decreased';
+      case AlertRuleType.crossedAboveThreshold:
+        return 'crossed_above_threshold';
+      case AlertRuleType.crossedBelowThreshold:
+        return 'crossed_below_threshold';
+      case AlertRuleType.serverOnline:
+        return 'server_online';
+      case AlertRuleType.serverOffline:
+        return 'server_offline';
+    }
+  }
+
+  static AlertRuleType fromFirestore(String value) {
+    switch (value) {
+      case 'population_increased':
+        return AlertRuleType.populationIncreased;
+      case 'population_decreased':
+        return AlertRuleType.populationDecreased;
+      case 'crossed_above_threshold':
+        return AlertRuleType.crossedAboveThreshold;
+      case 'crossed_below_threshold':
+        return AlertRuleType.crossedBelowThreshold;
+      case 'server_online':
+        return AlertRuleType.serverOnline;
+      case 'server_offline':
+        return AlertRuleType.serverOffline;
+      default:
+        throw ArgumentError('Unknown AlertRuleType value: $value');
+    }
+  }
+}

--- a/lib/features/alerts/domain/repositories/alert_rules_repository.dart
+++ b/lib/features/alerts/domain/repositories/alert_rules_repository.dart
@@ -1,0 +1,23 @@
+// features/alerts/domain/repositories/alert_rules_repository.dart
+import 'package:asa_server_eye/features/alerts/domain/entities/alert_rule.dart';
+
+abstract class AlertRulesRepository {
+  Stream<List<AlertRule>> watchRules(String userId);
+
+  Stream<List<AlertRule>> watchRulesForServer({
+    required String userId,
+    required String serverId,
+  });
+
+  Future<void> createRule(AlertRule rule);
+
+  Future<void> updateRule(AlertRule rule);
+
+  Future<void> deleteRule({required String userId, required String ruleId});
+
+  Future<void> setRuleEnabled({
+    required String userId,
+    required String ruleId,
+    required bool isEnabled,
+  });
+}

--- a/lib/features/alerts/presentation/controllers/alert_rule_mutation_controller.dart
+++ b/lib/features/alerts/presentation/controllers/alert_rule_mutation_controller.dart
@@ -1,0 +1,54 @@
+// features/alerts/presentation/providers/alert_rule_mutation_controller.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/alert_rule.dart';
+import '../providers/alert_rules_providers.dart';
+
+final alertRuleMutationControllerProvider =
+    AutoDisposeAsyncNotifierProvider<AlertRuleMutationController, void>(
+      AlertRuleMutationController.new,
+    );
+
+class AlertRuleMutationController extends AutoDisposeAsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  Future<void> createRule(AlertRule rule) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref.read(alertRulesRepositoryProvider).createRule(rule);
+    });
+  }
+
+  Future<void> updateRule(AlertRule rule) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref.read(alertRulesRepositoryProvider).updateRule(rule);
+    });
+  }
+
+  Future<void> deleteRule({
+    required String userId,
+    required String ruleId,
+  }) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref
+          .read(alertRulesRepositoryProvider)
+          .deleteRule(userId: userId, ruleId: ruleId);
+    });
+  }
+
+  Future<void> setRuleEnabled({
+    required String userId,
+    required String ruleId,
+    required bool isEnabled,
+  }) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref
+          .read(alertRulesRepositoryProvider)
+          .setRuleEnabled(userId: userId, ruleId: ruleId, isEnabled: isEnabled);
+    });
+  }
+}

--- a/lib/features/alerts/presentation/providers/alert_rules_providers.dart
+++ b/lib/features/alerts/presentation/providers/alert_rules_providers.dart
@@ -1,0 +1,42 @@
+// features/alerts/presentation/providers/alert_rules_providers.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../auth/presentation/providers/auth_state_provider.dart';
+import '../../data/repositories/firestore_alert_rules_repository.dart';
+import '../../domain/entities/alert_rule.dart';
+import '../../domain/repositories/alert_rules_repository.dart';
+
+final alertRulesRepositoryProvider = Provider<AlertRulesRepository>((ref) {
+  return FirestoreAlertRulesRepository(FirebaseFirestore.instance);
+});
+
+final currentUserIdProvider = Provider<String?>((ref) {
+  final authState = ref.watch(authStateProvider).value;
+  return authState?.uid;
+});
+
+final userAlertRulesProvider = StreamProvider.autoDispose<List<AlertRule>>((
+  ref,
+) {
+  final userId = ref.watch(currentUserIdProvider);
+
+  if (userId == null) {
+    return const Stream.empty();
+  }
+
+  return ref.watch(alertRulesRepositoryProvider).watchRules(userId);
+});
+
+final serverAlertRulesProvider = StreamProvider.autoDispose
+    .family<List<AlertRule>, String>((ref, serverId) {
+      final userId = ref.watch(currentUserIdProvider);
+
+      if (userId == null) {
+        return const Stream.empty();
+      }
+
+      return ref
+          .watch(alertRulesRepositoryProvider)
+          .watchRulesForServer(userId: userId, serverId: serverId);
+    });


### PR DESCRIPTION
## Summary
Adds the first alerts MVP foundation.

## Changes
- adds alert rule domain, DTO, repository, providers, and mutation controller
- adds Firestore rules for users/{uid}/alert_rules/{ruleId}

## Validation
- flutter analyze passes
- firestore rules deploy passes

## Zusammenfassung von Sourcery

Einführung eines Alert-Domain-Modells mit Firestore-basierter Persistenz und Riverpod-Integration zur Verwaltung von Benutzer-Alert-Regeln.

Neue Features:
- Hinzufügen der Domain-Modelle `AlertRule` und `AlertRuleType`, um konfigurierbare Server-Alerts darzustellen.
- Hinzufügen des `FirestoreAlertRulesRepository` mit CRUD- sowie Aktivieren/Deaktivieren-Operationen für Benutzer-Alert-Regeln, die unter `users/{uid}/alert_rules` gespeichert werden.
- Bereitstellung von Riverpod-Providern und eines `AlertRuleMutationController`, um Alert-Regeln für den aktuellen Benutzer und bestimmte Server zu streamen und zu verändern.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Einführen eines Alerts-Domain-Modells auf Basis von Firestore und Integration in Riverpod, um benutzerspezifische Alert-Regeln zu streamen und zu verändern.

Neue Funktionen:
- Hinzufügen der Domain-Modelle `AlertRule` und `AlertRuleType`, um konfigurierbare Server-Alert-Regeln darzustellen.
- Persistieren von Benutzer-Alert-Regeln in Firestore unter `users/{uid}/alert_rules` mit einem `FirestoreAlertRulesRepository`, das CRUD- sowie Aktivierungs-/Deaktivierungsoperationen implementiert.
- Bereitstellen von Riverpod-Providern und eines `AlertRuleMutationController`, um Alert-Regeln für den aktuellen Benutzer und einzelne Server zu streamen sowie Regeländerungen aus dem UI heraus durchzuführen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an alerts domain model backed by Firestore and hook it into Riverpod for streaming and mutating user-specific alert rules.

New Features:
- Add AlertRule and AlertRuleType domain models to represent configurable server alert rules.
- Persist user alert rules in Firestore under users/{uid}/alert_rules with a FirestoreAlertRulesRepository implementing CRUD and enable/disable operations.
- Expose Riverpod providers and an AlertRuleMutationController to stream alert rules for the current user and individual servers and to perform rule mutations from the UI.

</details>

</details>