### PR TITLE
feat(servers): show sync status and cache source in server list

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/features/servers/presentation/screens/server_list_screen.dart
+++ b/lib/features/servers/presentation/screens/server_list_screen.dart
@@ -6,10 +6,12 @@ import '../../../../core/extensions/context_l10n.dart';
 import '../../../../core/presentation/widgets/ad_banner_widget.dart';
 import '../providers/filtered_servers_provider.dart';
 import '../providers/server_search_provider.dart';
+import '../providers/servers_provider.dart';
 import '../utils/server_navigation.dart';
 import '../utils/server_refresh_action.dart';
 import '../widgets/server_list_item.dart';
 import '../widgets/server_search_section.dart';
+import '../widgets/server_sync_status_card.dart';
 
 class ServerListScreen extends ConsumerWidget {
   const ServerListScreen({super.key});
@@ -18,6 +20,7 @@ class ServerListScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final searchController = ref.watch(serverSearchProvider);
     final filteredServersAsync = ref.watch(filteredServersProvider);
+    final syncStateAsync = ref.watch(serverSyncStateProvider);
     final theme = Theme.of(context);
 
     return Scaffold(
@@ -26,14 +29,24 @@ class ServerListScreen extends ConsumerWidget {
         children: [
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-            child: ServerSearchSection(
-              title: context.l10n.servers,
-              subtitle: context.l10n.searchServersOrMaps,
-              hintText: context.l10n.searchServersOrMaps,
-              controller: searchController.textController,
-              query: searchController.query,
-              onChanged: searchController.updateQuery,
-              onClear: searchController.clear,
+            child: Column(
+              children: [
+                ServerSearchSection(
+                  title: context.l10n.servers,
+                  subtitle: context.l10n.searchServersOrMaps,
+                  hintText: context.l10n.searchServersOrMaps,
+                  controller: searchController.textController,
+                  query: searchController.query,
+                  onChanged: searchController.updateQuery,
+                  onClear: searchController.clear,
+                ),
+                const SizedBox(height: 8),
+                syncStateAsync.whenOrNull(
+                      data: (syncState) =>
+                          ServerSyncStatusCard(syncState: syncState),
+                    ) ??
+                    const SizedBox.shrink(),
+              ],
             ),
           ),
           Expanded(

--- a/lib/features/servers/presentation/widgets/server_sync_status_card.dart
+++ b/lib/features/servers/presentation/widgets/server_sync_status_card.dart
@@ -86,7 +86,7 @@ class ServerSyncStatusCard extends StatelessWidget {
     final date = localizations.formatShortDate(localTime);
     final time = localizations.formatTimeOfDay(
       TimeOfDay.fromDateTime(localTime),
-      alwaysUse24HourFormat: true,
+      alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context),
     );
 
     return context.l10n.serverSyncLastUpdated('$date, $time');

--- a/lib/features/servers/presentation/widgets/server_sync_status_card.dart
+++ b/lib/features/servers/presentation/widgets/server_sync_status_card.dart
@@ -1,0 +1,94 @@
+// features/servers/presentation/widgets/server_sync_status_card.dart
+import 'package:flutter/material.dart';
+
+import '../../../../core/extensions/context_l10n.dart';
+import '../../presentation/state/server_sync_state.dart';
+
+class ServerSyncStatusCard extends StatelessWidget {
+  const ServerSyncStatusCard({super.key, required this.syncState});
+
+  final ServerSyncState syncState;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final lastUpdatedText = _buildLastUpdatedText(context, syncState);
+    final sourceText = syncState.isFromCache
+        ? context.l10n.serverSyncSourceCache
+        : context.l10n.serverSyncSourceLive;
+
+    final showCacheBanner = syncState.isFromCache;
+    final showStaleHint = syncState.isFromCache && syncState.isStale;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: showCacheBanner
+              ? colorScheme.outline
+              : colorScheme.outlineVariant,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (showCacheBanner)
+            Container(
+              margin: const EdgeInsets.only(bottom: 8),
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              decoration: BoxDecoration(
+                color: colorScheme.secondaryContainer,
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: Text(
+                context.l10n.serverSyncCacheBanner,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: colorScheme.onSecondaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          Text(lastUpdatedText, style: theme.textTheme.bodyMedium),
+          const SizedBox(height: 4),
+          Text(sourceText, style: theme.textTheme.bodySmall),
+          if (showStaleHint) ...[
+            const SizedBox(height: 6),
+            Text(
+              context.l10n.serverSyncCacheStale,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colorScheme.error,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _buildLastUpdatedText(
+    BuildContext context,
+    ServerSyncState syncState,
+  ) {
+    final lastUpdatedAt = syncState.lastUpdatedAt;
+
+    if (lastUpdatedAt == null) {
+      return context.l10n.serverSyncUnknownUpdateTime;
+    }
+
+    final localTime = lastUpdatedAt.toLocal();
+    final localizations = MaterialLocalizations.of(context);
+
+    final date = localizations.formatShortDate(localTime);
+    final time = localizations.formatTimeOfDay(
+      TimeOfDay.fromDateTime(localTime),
+      alwaysUse24HourFormat: true,
+    );
+
+    return context.l10n.serverSyncLastUpdated('$date, $time');
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -878,5 +878,38 @@
   "premiumVerificationQueued": "Dein Kauf wurde übermittelt und wird jetzt verifiziert.",
   "@premiumVerificationQueued": {
     "description": "Hinweis nach dem Übermitteln eines Kauf-Requests"
+  },
+  "serverSyncLastUpdated": "Zuletzt aktualisiert: {value}",
+  "@serverSyncLastUpdated": {
+    "description": "Label showing when the server list was last updated",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "serverSyncSourceLive": "Quelle: Live-Daten",
+  "@serverSyncSourceLive": {
+    "description": "Label showing that server data comes from the network"
+  },
+  "serverSyncSourceCache": "Quelle: Cache",
+  "@serverSyncSourceCache": {
+    "description": "Label showing that server data comes from cache"
+  },
+  "serverSyncCacheBanner": "Es werden zwischengespeicherte Serverdaten angezeigt",
+  "@serverSyncCacheBanner": {
+    "description": "Banner text when cached server data is displayed"
+  },
+  "serverSyncCacheStale": "Cache-Daten könnten veraltet sein",
+  "@serverSyncCacheStale": {
+    "description": "Hint when cached data is stale"
+  },
+  "serverSyncUnknownUpdateTime": "Zuletzt aktualisiert: Unbekannt",
+  "@serverSyncUnknownUpdateTime": {
+    "description": "Fallback label when no update time is available"
+  },
+  "serverSyncUnknownSource": "Quelle: Unbekannt",
+  "@serverSyncUnknownSource": {
+    "description": "Fallback label when server data source is unknown"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -907,9 +907,5 @@
   "serverSyncUnknownUpdateTime": "Zuletzt aktualisiert: Unbekannt",
   "@serverSyncUnknownUpdateTime": {
     "description": "Fallback label when no update time is available"
-  },
-  "serverSyncUnknownSource": "Quelle: Unbekannt",
-  "@serverSyncUnknownSource": {
-    "description": "Fallback label when server data source is unknown"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -878,5 +878,38 @@
   "premiumVerificationQueued": "Your purchase was submitted and is now being verified.",
   "@premiumVerificationQueued": {
     "description": "Message after purchase verification request was submitted"
+  },
+  "serverSyncLastUpdated": "Last updated: {value}",
+  "@serverSyncLastUpdated": {
+    "description": "Label showing when the server list was last updated",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "serverSyncSourceLive": "Source: Live data",
+  "@serverSyncSourceLive": {
+    "description": "Label showing that server data comes from the network"
+  },
+  "serverSyncSourceCache": "Source: Cache",
+  "@serverSyncSourceCache": {
+    "description": "Label showing that server data comes from cache"
+  },
+  "serverSyncCacheBanner": "Showing cached server data",
+  "@serverSyncCacheBanner": {
+    "description": "Banner text when cached server data is displayed"
+  },
+  "serverSyncCacheStale": "Cache may be outdated",
+  "@serverSyncCacheStale": {
+    "description": "Hint when cached data is stale"
+  },
+  "serverSyncUnknownUpdateTime": "Last updated: Unknown",
+  "@serverSyncUnknownUpdateTime": {
+    "description": "Fallback label when no update time is available"
+  },
+  "serverSyncUnknownSource": "Source: Unknown",
+  "@serverSyncUnknownSource": {
+    "description": "Fallback label when server data source is unknown"
   }
 } 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -907,9 +907,5 @@
   "serverSyncUnknownUpdateTime": "Last updated: Unknown",
   "@serverSyncUnknownUpdateTime": {
     "description": "Fallback label when no update time is available"
-  },
-  "serverSyncUnknownSource": "Source: Unknown",
-  "@serverSyncUnknownSource": {
-    "description": "Fallback label when server data source is unknown"
   }
 } 

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -878,5 +878,38 @@
     "premiumVerificationQueued": "Tu compra fue enviada y ahora está siendo verificada.",
     "@premiumVerificationQueued": {
         "description": "Mensaje después de que se envíe la solicitud de verificación de compra"
+    },
+    "serverSyncLastUpdated": "Última actualización: {value}",
+  "@serverSyncLastUpdated": {
+    "description": "Etiqueta para la última vez que se sincronizó con el servidor",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
     }
+  },
+  "serverSyncSourceLive": "Fuente: Datos en vivo",
+  "@serverSyncSourceLive": {
+    "description": "Etiqueta para indicar que los datos del servidor provienen de la red"
+  },
+  "serverSyncSourceCache": "Fuente: Caché",
+  "@serverSyncSourceCache": {
+    "description": "Etiqueta para indicar que los datos del servidor provienen de la caché"
+  },
+  "serverSyncCacheBanner": "Se están mostrando datos de servidor en caché",
+  "@serverSyncCacheBanner": {
+    "description": "Texto del banner cuando se muestran datos de servidor en caché"
+  },
+  "serverSyncCacheStale": "Los datos en caché podrían estar desactualizados",
+  "@serverSyncCacheStale": {
+    "description": "Sugerencia cuando los datos en caché están desactualizados"
+  },
+  "serverSyncUnknownUpdateTime": "Última actualización: Desconocida",
+  "@serverSyncUnknownUpdateTime": {
+    "description": "Etiqueta para la última vez que se sincronizó con el servidor cuando no se conoce el tiempo de actualización"
+  },
+  "serverSyncUnknownSource": "Fuente: Desconocida",
+  "@serverSyncUnknownSource": {
+    "description": "Etiqueta de repli cuando la source de los datos del servidor no está disponible"
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -907,9 +907,5 @@
   "serverSyncUnknownUpdateTime": "Última actualización: Desconocida",
   "@serverSyncUnknownUpdateTime": {
     "description": "Etiqueta para la última vez que se sincronizó con el servidor cuando no se conoce el tiempo de actualización"
-  },
-  "serverSyncUnknownSource": "Fuente: Desconocida",
-  "@serverSyncUnknownSource": {
-    "description": "Etiqueta de repli cuando la source de los datos del servidor no está disponible"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -888,11 +888,11 @@
       }
     }
   },
-  "serverSyncSourceLive": "Quelle: Réseau",
+  "serverSyncSourceLive": "Source: Réseau",
   "@serverSyncSourceLive": {
     "description": "Libellé indiquant que les données du serveur proviennent du réseau"
   },
-  "serverSyncSourceCache": "Quelle: Cache",
+  "serverSyncSourceCache": "Source: Cache",
   "@serverSyncSourceCache": {
     "description": "Libellé indiquant que les données du serveur proviennent de la cache"
   },
@@ -907,9 +907,5 @@
   "serverSyncUnknownUpdateTime": "Dernière mise à jour: Inconnue",
   "@serverSyncUnknownUpdateTime": {
     "description": "Libellé de repli lorsque l'heure de mise à jour n'est pas disponible"
-  },
-  "serverSyncUnknownSource": "Quelle: Inconnue",
-  "@serverSyncUnknownSource": {
-    "description": "Libellé de repli lorsque la source des données du serveur n'est pas disponible"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -878,5 +878,38 @@
     "premiumVerificationQueued": "Votre achat a été soumis et est maintenant en cours de vérification.",
     "@premiumVerificationQueued": {
         "description": "Affiché lorsque l'achat de premium est en cours de vérification"
+    },
+    "serverSyncLastUpdated": "Dernière mise à jour: {value}",
+  "@serverSyncLastUpdated": {
+    "description": "Libellé de la dernière mise à jour des données du serveur",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
     }
+  },
+  "serverSyncSourceLive": "Quelle: Réseau",
+  "@serverSyncSourceLive": {
+    "description": "Libellé indiquant que les données du serveur proviennent du réseau"
+  },
+  "serverSyncSourceCache": "Quelle: Cache",
+  "@serverSyncSourceCache": {
+    "description": "Libellé indiquant que les données du serveur proviennent de la cache"
+  },
+  "serverSyncCacheBanner": "Les données du serveur en cache sont affichées",
+  "@serverSyncCacheBanner": {
+    "description": "Texte du bandeau lorsque les données du serveur en cache sont affichées"
+  },
+  "serverSyncCacheStale": "Les données en cache pourraient être obsolètes",
+  "@serverSyncCacheStale": {
+    "description": "Indication lorsque les données en cache sont obsolètes"
+  },
+  "serverSyncUnknownUpdateTime": "Dernière mise à jour: Inconnue",
+  "@serverSyncUnknownUpdateTime": {
+    "description": "Libellé de repli lorsque l'heure de mise à jour n'est pas disponible"
+  },
+  "serverSyncUnknownSource": "Quelle: Inconnue",
+  "@serverSyncUnknownSource": {
+    "description": "Libellé de repli lorsque la source des données du serveur n'est pas disponible"
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1372,12 +1372,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Last updated: Unknown'**
   String get serverSyncUnknownUpdateTime;
-
-  /// Fallback label when server data source is unknown
-  ///
-  /// In en, this message translates to:
-  /// **'Source: Unknown'**
-  String get serverSyncUnknownSource;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1336,6 +1336,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Your purchase was submitted and is now being verified.'**
   String get premiumVerificationQueued;
+
+  /// Label showing when the server list was last updated
+  ///
+  /// In en, this message translates to:
+  /// **'Last updated: {value}'**
+  String serverSyncLastUpdated(String value);
+
+  /// Label showing that server data comes from the network
+  ///
+  /// In en, this message translates to:
+  /// **'Source: Live data'**
+  String get serverSyncSourceLive;
+
+  /// Label showing that server data comes from cache
+  ///
+  /// In en, this message translates to:
+  /// **'Source: Cache'**
+  String get serverSyncSourceCache;
+
+  /// Banner text when cached server data is displayed
+  ///
+  /// In en, this message translates to:
+  /// **'Showing cached server data'**
+  String get serverSyncCacheBanner;
+
+  /// Hint when cached data is stale
+  ///
+  /// In en, this message translates to:
+  /// **'Cache may be outdated'**
+  String get serverSyncCacheStale;
+
+  /// Fallback label when no update time is available
+  ///
+  /// In en, this message translates to:
+  /// **'Last updated: Unknown'**
+  String get serverSyncUnknownUpdateTime;
+
+  /// Fallback label when server data source is unknown
+  ///
+  /// In en, this message translates to:
+  /// **'Source: Unknown'**
+  String get serverSyncUnknownSource;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -667,7 +667,4 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => 'Zuletzt aktualisiert: Unbekannt';
-
-  @override
-  String get serverSyncUnknownSource => 'Quelle: Unbekannt';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -647,4 +647,27 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get premiumVerificationQueued => 'Dein Kauf wurde übermittelt und wird jetzt verifiziert.';
+
+  @override
+  String serverSyncLastUpdated(String value) {
+    return 'Zuletzt aktualisiert: $value';
+  }
+
+  @override
+  String get serverSyncSourceLive => 'Quelle: Live-Daten';
+
+  @override
+  String get serverSyncSourceCache => 'Quelle: Cache';
+
+  @override
+  String get serverSyncCacheBanner => 'Es werden zwischengespeicherte Serverdaten angezeigt';
+
+  @override
+  String get serverSyncCacheStale => 'Cache-Daten könnten veraltet sein';
+
+  @override
+  String get serverSyncUnknownUpdateTime => 'Zuletzt aktualisiert: Unbekannt';
+
+  @override
+  String get serverSyncUnknownSource => 'Quelle: Unbekannt';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -647,4 +647,27 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get premiumVerificationQueued => 'Your purchase was submitted and is now being verified.';
+
+  @override
+  String serverSyncLastUpdated(String value) {
+    return 'Last updated: $value';
+  }
+
+  @override
+  String get serverSyncSourceLive => 'Source: Live data';
+
+  @override
+  String get serverSyncSourceCache => 'Source: Cache';
+
+  @override
+  String get serverSyncCacheBanner => 'Showing cached server data';
+
+  @override
+  String get serverSyncCacheStale => 'Cache may be outdated';
+
+  @override
+  String get serverSyncUnknownUpdateTime => 'Last updated: Unknown';
+
+  @override
+  String get serverSyncUnknownSource => 'Source: Unknown';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -667,7 +667,4 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => 'Last updated: Unknown';
-
-  @override
-  String get serverSyncUnknownSource => 'Source: Unknown';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -647,4 +647,27 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get premiumVerificationQueued => 'Tu compra fue enviada y ahora está siendo verificada.';
+
+  @override
+  String serverSyncLastUpdated(String value) {
+    return 'Última actualización: $value';
+  }
+
+  @override
+  String get serverSyncSourceLive => 'Fuente: Datos en vivo';
+
+  @override
+  String get serverSyncSourceCache => 'Fuente: Caché';
+
+  @override
+  String get serverSyncCacheBanner => 'Se están mostrando datos de servidor en caché';
+
+  @override
+  String get serverSyncCacheStale => 'Los datos en caché podrían estar desactualizados';
+
+  @override
+  String get serverSyncUnknownUpdateTime => 'Última actualización: Desconocida';
+
+  @override
+  String get serverSyncUnknownSource => 'Fuente: Desconocida';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -667,7 +667,4 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => 'Última actualización: Desconocida';
-
-  @override
-  String get serverSyncUnknownSource => 'Fuente: Desconocida';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -654,10 +654,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get serverSyncSourceLive => 'Quelle: Réseau';
+  String get serverSyncSourceLive => 'Source: Réseau';
 
   @override
-  String get serverSyncSourceCache => 'Quelle: Cache';
+  String get serverSyncSourceCache => 'Source: Cache';
 
   @override
   String get serverSyncCacheBanner => 'Les données du serveur en cache sont affichées';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -667,7 +667,4 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => 'Dernière mise à jour: Inconnue';
-
-  @override
-  String get serverSyncUnknownSource => 'Quelle: Inconnue';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -647,4 +647,27 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get premiumVerificationQueued => 'Votre achat a été soumis et est maintenant en cours de vérification.';
+
+  @override
+  String serverSyncLastUpdated(String value) {
+    return 'Dernière mise à jour: $value';
+  }
+
+  @override
+  String get serverSyncSourceLive => 'Quelle: Réseau';
+
+  @override
+  String get serverSyncSourceCache => 'Quelle: Cache';
+
+  @override
+  String get serverSyncCacheBanner => 'Les données du serveur en cache sont affichées';
+
+  @override
+  String get serverSyncCacheStale => 'Les données en cache pourraient être obsolètes';
+
+  @override
+  String get serverSyncUnknownUpdateTime => 'Dernière mise à jour: Inconnue';
+
+  @override
+  String get serverSyncUnknownSource => 'Quelle: Inconnue';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -647,4 +647,27 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get premiumVerificationQueued => '您的购买已提交，目前正在验证中。';
+
+  @override
+  String serverSyncLastUpdated(String value) {
+    return '最后更新：$value';
+  }
+
+  @override
+  String get serverSyncSourceLive => '来源：实时数据';
+
+  @override
+  String get serverSyncSourceCache => '来源：缓存';
+
+  @override
+  String get serverSyncCacheBanner => '当前显示的是缓存的服务器数据';
+
+  @override
+  String get serverSyncCacheStale => '缓存数据可能已过期';
+
+  @override
+  String get serverSyncUnknownUpdateTime => '最后更新：未知';
+
+  @override
+  String get serverSyncUnknownSource => '来源：未知';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -667,7 +667,4 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => '最后更新：未知';
-
-  @override
-  String get serverSyncUnknownSource => '来源：未知';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -811,9 +811,5 @@
     "serverSyncUnknownUpdateTime": "最后更新：未知",
     "@serverSyncUnknownUpdateTime": {
         "description": "当没有可用更新时间时的回退标签"
-    },
-    "serverSyncUnknownSource": "来源：未知",
-    "@serverSyncUnknownSource": {
-    "description": "当服务器数据来源未知时的回退标签"
     }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -782,5 +782,38 @@
     "premiumVerificationQueued": "您的购买已提交，目前正在验证中。",
     "@premiumVerificationQueued": {
         "description": "购买验证请求提交后显示的消息"
+    },
+    "serverSyncLastUpdated": "最后更新：{value}",
+    "@serverSyncLastUpdated": {
+        "description": "显示服务器列表最后更新时间的标签",
+        "placeholders": {
+            "value": {
+            "type": "String"
+        }
+    }
+    },
+    "serverSyncSourceLive": "来源：实时数据",
+    "@serverSyncSourceLive": {
+    "description": "显示服务器数据来自实时网络的标签"
+    },
+    "serverSyncSourceCache": "来源：缓存",
+    "@serverSyncSourceCache": {
+    "description": "显示服务器数据来自缓存的标签"
+    },
+    "serverSyncCacheBanner": "当前显示的是缓存的服务器数据",
+    "@serverSyncCacheBanner": {
+    "description": "当显示缓存服务器数据时的横幅文本"
+    },
+    "serverSyncCacheStale": "缓存数据可能已过期",
+    "@serverSyncCacheStale": {
+        "description": "当缓存数据可能已过期时的提示"
+    },
+    "serverSyncUnknownUpdateTime": "最后更新：未知",
+    "@serverSyncUnknownUpdateTime": {
+        "description": "当没有可用更新时间时的回退标签"
+    },
+    "serverSyncUnknownSource": "来源：未知",
+    "@serverSyncUnknownSource": {
+    "description": "当服务器数据来源未知时的回退标签"
     }
 }


### PR DESCRIPTION
## Summary
Adds a compact sync status card to the server list screen so users can see when the list was last updated and whether the current data comes from the network or cache.

## Changes
- add `ServerSyncStatusCard` above the server list
- show the last successful update time
- show whether the current data source is live or cache
- show a visible cached-data banner and stale-cache hint
- add localized strings for de, en, es, fr, and zh

## Validation
- `flutter gen-l10n`
- `flutter analyze`

Closes #69

## Zusammenfassung von Sourcery

Fügt eine Sync-Status-Karte zur Serverliste hinzu, die die letzte Aktualisierungszeit und die Datenquelle anzeigt, mit lokalisierten Meldungen und Cache-Status-Indikatoren sowie einer DevTools-Konfigurationsdatei.

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte erfolgreiche Aktualisierungszeit und den Hinweis zeigt, ob die Daten live oder aus dem Cache stammen.

Verbesserungen:
- Kennzeichnung, wenn Serverdaten aus dem Cache bereitgestellt werden, einschließlich eines sichtbaren Banners und einer Warnmeldung für veraltete Caches.
- Hinzufügen lokalisierter Zeichenketten für den Server-Sync-Status, Cache-Indikatoren und Fallback-Beschriftungen in allen unterstützten Sprachen (de, en, es, fr, zh).

Routinearbeiten:
- Einführung einer Datei `devtools_options.yaml` zur Speicherung von Dart- und Flutter-DevTools-Einstellungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sync status card to the server list that surfaces last update time and data source, with localized messaging and cache-state indicators, plus a DevTools configuration file.

New Features:
- Display a ServerSyncStatusCard above the server list showing last successful update time and whether data is live or from cache.

Enhancements:
- Indicate when server data is served from cache, including a visible banner and stale-cache warning message.
- Add localized strings for server sync status, cache indicators, and fallback labels across supported languages (de, en, es, fr, zh).

Chores:
- Introduce a devtools_options.yaml file to store Dart and Flutter DevTools settings.

</details>

Neue Funktionen:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte Aktualisierungszeit und die Datenquelle (Live vs. Cache) zeigt.

Verbesserungen:
- Deutliche Banner und Hinweise anzeigen, wenn Serverdaten aus dem Cache geliefert werden oder wenn der Cache möglicherweise veraltet ist.
- Lokalisierte Sync-Status-Strings und Fallbacks für alle unterstützten Sprachen (de, en, es, fr, zh) hinzufügen.
- Eine DevTools-Konfigurationsdatei einführen, um Dart- und Flutter-DevTools-Einstellungen zu speichern.

<details>
<summary>Original summary in English</summary>

## Zusammenfassung von Sourcery

Fügt eine Sync-Status-Karte zur Serverliste hinzu, die die letzte Aktualisierungszeit und die Datenquelle anzeigt, mit lokalisierten Meldungen und Cache-Status-Indikatoren sowie einer DevTools-Konfigurationsdatei.

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte erfolgreiche Aktualisierungszeit und den Hinweis zeigt, ob die Daten live oder aus dem Cache stammen.

Verbesserungen:
- Kennzeichnung, wenn Serverdaten aus dem Cache bereitgestellt werden, einschließlich eines sichtbaren Banners und einer Warnmeldung für veraltete Caches.
- Hinzufügen lokalisierter Zeichenketten für den Server-Sync-Status, Cache-Indikatoren und Fallback-Beschriftungen in allen unterstützten Sprachen (de, en, es, fr, zh).

Routinearbeiten:
- Einführung einer Datei `devtools_options.yaml` zur Speicherung von Dart- und Flutter-DevTools-Einstellungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sync status card to the server list that surfaces last update time and data source, with localized messaging and cache-state indicators, plus a DevTools configuration file.

New Features:
- Display a ServerSyncStatusCard above the server list showing last successful update time and whether data is live or from cache.

Enhancements:
- Indicate when server data is served from cache, including a visible banner and stale-cache warning message.
- Add localized strings for server sync status, cache indicators, and fallback labels across supported languages (de, en, es, fr, zh).

Chores:
- Introduce a devtools_options.yaml file to store Dart and Flutter DevTools settings.

</details>

</details>

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die Zeit der letzten Aktualisierung und die Datenquelle (Live vs. Cache) angibt.

Verbesserungen:
- Hinzufügen lokalisierter Sync-Status-Strings und Fallbacks für alle unterstützten Sprachen (de, en, es, fr, zh).

<details>
<summary>Original summary in English</summary>

## Zusammenfassung von Sourcery

Fügt eine Sync-Status-Karte zur Serverliste hinzu, die die letzte Aktualisierungszeit und die Datenquelle anzeigt, mit lokalisierten Meldungen und Cache-Status-Indikatoren sowie einer DevTools-Konfigurationsdatei.

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte erfolgreiche Aktualisierungszeit und den Hinweis zeigt, ob die Daten live oder aus dem Cache stammen.

Verbesserungen:
- Kennzeichnung, wenn Serverdaten aus dem Cache bereitgestellt werden, einschließlich eines sichtbaren Banners und einer Warnmeldung für veraltete Caches.
- Hinzufügen lokalisierter Zeichenketten für den Server-Sync-Status, Cache-Indikatoren und Fallback-Beschriftungen in allen unterstützten Sprachen (de, en, es, fr, zh).

Routinearbeiten:
- Einführung einer Datei `devtools_options.yaml` zur Speicherung von Dart- und Flutter-DevTools-Einstellungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sync status card to the server list that surfaces last update time and data source, with localized messaging and cache-state indicators, plus a DevTools configuration file.

New Features:
- Display a ServerSyncStatusCard above the server list showing last successful update time and whether data is live or from cache.

Enhancements:
- Indicate when server data is served from cache, including a visible banner and stale-cache warning message.
- Add localized strings for server sync status, cache indicators, and fallback labels across supported languages (de, en, es, fr, zh).

Chores:
- Introduce a devtools_options.yaml file to store Dart and Flutter DevTools settings.

</details>

Neue Funktionen:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte Aktualisierungszeit und die Datenquelle (Live vs. Cache) zeigt.

Verbesserungen:
- Deutliche Banner und Hinweise anzeigen, wenn Serverdaten aus dem Cache geliefert werden oder wenn der Cache möglicherweise veraltet ist.
- Lokalisierte Sync-Status-Strings und Fallbacks für alle unterstützten Sprachen (de, en, es, fr, zh) hinzufügen.
- Eine DevTools-Konfigurationsdatei einführen, um Dart- und Flutter-DevTools-Einstellungen zu speichern.

<details>
<summary>Original summary in English</summary>

## Zusammenfassung von Sourcery

Fügt eine Sync-Status-Karte zur Serverliste hinzu, die die letzte Aktualisierungszeit und die Datenquelle anzeigt, mit lokalisierten Meldungen und Cache-Status-Indikatoren sowie einer DevTools-Konfigurationsdatei.

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte erfolgreiche Aktualisierungszeit und den Hinweis zeigt, ob die Daten live oder aus dem Cache stammen.

Verbesserungen:
- Kennzeichnung, wenn Serverdaten aus dem Cache bereitgestellt werden, einschließlich eines sichtbaren Banners und einer Warnmeldung für veraltete Caches.
- Hinzufügen lokalisierter Zeichenketten für den Server-Sync-Status, Cache-Indikatoren und Fallback-Beschriftungen in allen unterstützten Sprachen (de, en, es, fr, zh).

Routinearbeiten:
- Einführung einer Datei `devtools_options.yaml` zur Speicherung von Dart- und Flutter-DevTools-Einstellungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sync status card to the server list that surfaces last update time and data source, with localized messaging and cache-state indicators, plus a DevTools configuration file.

New Features:
- Display a ServerSyncStatusCard above the server list showing last successful update time and whether data is live or from cache.

Enhancements:
- Indicate when server data is served from cache, including a visible banner and stale-cache warning message.
- Add localized strings for server sync status, cache indicators, and fallback labels across supported languages (de, en, es, fr, zh).

Chores:
- Introduce a devtools_options.yaml file to store Dart and Flutter DevTools settings.

</details>

</details>

</details>

Neue Funktionen:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die Zeit der letzten erfolgreichen Aktualisierung und die Datenquelle (Live vs. Cache) zeigt.
- Anzeige eines Cache-Banners und einer Warnung bei veraltetem Cache, wenn Serverdaten aus einem veralteten Cache bereitgestellt werden.

Verbesserungen:
- Hinzufügen lokalisierter Sync-Status-Strings und Fallbacks für alle unterstützten Sprachen (de, en, es, fr, zh).

<details>
<summary>Original summary in English</summary>

## Zusammenfassung von Sourcery

Fügt eine Sync-Status-Karte zur Serverliste hinzu, die die letzte Aktualisierungszeit und die Datenquelle anzeigt, mit lokalisierten Meldungen und Cache-Status-Indikatoren sowie einer DevTools-Konfigurationsdatei.

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte erfolgreiche Aktualisierungszeit und den Hinweis zeigt, ob die Daten live oder aus dem Cache stammen.

Verbesserungen:
- Kennzeichnung, wenn Serverdaten aus dem Cache bereitgestellt werden, einschließlich eines sichtbaren Banners und einer Warnmeldung für veraltete Caches.
- Hinzufügen lokalisierter Zeichenketten für den Server-Sync-Status, Cache-Indikatoren und Fallback-Beschriftungen in allen unterstützten Sprachen (de, en, es, fr, zh).

Routinearbeiten:
- Einführung einer Datei `devtools_options.yaml` zur Speicherung von Dart- und Flutter-DevTools-Einstellungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sync status card to the server list that surfaces last update time and data source, with localized messaging and cache-state indicators, plus a DevTools configuration file.

New Features:
- Display a ServerSyncStatusCard above the server list showing last successful update time and whether data is live or from cache.

Enhancements:
- Indicate when server data is served from cache, including a visible banner and stale-cache warning message.
- Add localized strings for server sync status, cache indicators, and fallback labels across supported languages (de, en, es, fr, zh).

Chores:
- Introduce a devtools_options.yaml file to store Dart and Flutter DevTools settings.

</details>

Neue Funktionen:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte Aktualisierungszeit und die Datenquelle (Live vs. Cache) zeigt.

Verbesserungen:
- Deutliche Banner und Hinweise anzeigen, wenn Serverdaten aus dem Cache geliefert werden oder wenn der Cache möglicherweise veraltet ist.
- Lokalisierte Sync-Status-Strings und Fallbacks für alle unterstützten Sprachen (de, en, es, fr, zh) hinzufügen.
- Eine DevTools-Konfigurationsdatei einführen, um Dart- und Flutter-DevTools-Einstellungen zu speichern.

<details>
<summary>Original summary in English</summary>

## Zusammenfassung von Sourcery

Fügt eine Sync-Status-Karte zur Serverliste hinzu, die die letzte Aktualisierungszeit und die Datenquelle anzeigt, mit lokalisierten Meldungen und Cache-Status-Indikatoren sowie einer DevTools-Konfigurationsdatei.

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte erfolgreiche Aktualisierungszeit und den Hinweis zeigt, ob die Daten live oder aus dem Cache stammen.

Verbesserungen:
- Kennzeichnung, wenn Serverdaten aus dem Cache bereitgestellt werden, einschließlich eines sichtbaren Banners und einer Warnmeldung für veraltete Caches.
- Hinzufügen lokalisierter Zeichenketten für den Server-Sync-Status, Cache-Indikatoren und Fallback-Beschriftungen in allen unterstützten Sprachen (de, en, es, fr, zh).

Routinearbeiten:
- Einführung einer Datei `devtools_options.yaml` zur Speicherung von Dart- und Flutter-DevTools-Einstellungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sync status card to the server list that surfaces last update time and data source, with localized messaging and cache-state indicators, plus a DevTools configuration file.

New Features:
- Display a ServerSyncStatusCard above the server list showing last successful update time and whether data is live or from cache.

Enhancements:
- Indicate when server data is served from cache, including a visible banner and stale-cache warning message.
- Add localized strings for server sync status, cache indicators, and fallback labels across supported languages (de, en, es, fr, zh).

Chores:
- Introduce a devtools_options.yaml file to store Dart and Flutter DevTools settings.

</details>

</details>

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die Zeit der letzten Aktualisierung und die Datenquelle (Live vs. Cache) angibt.

Verbesserungen:
- Hinzufügen lokalisierter Sync-Status-Strings und Fallbacks für alle unterstützten Sprachen (de, en, es, fr, zh).

<details>
<summary>Original summary in English</summary>

## Zusammenfassung von Sourcery

Fügt eine Sync-Status-Karte zur Serverliste hinzu, die die letzte Aktualisierungszeit und die Datenquelle anzeigt, mit lokalisierten Meldungen und Cache-Status-Indikatoren sowie einer DevTools-Konfigurationsdatei.

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte erfolgreiche Aktualisierungszeit und den Hinweis zeigt, ob die Daten live oder aus dem Cache stammen.

Verbesserungen:
- Kennzeichnung, wenn Serverdaten aus dem Cache bereitgestellt werden, einschließlich eines sichtbaren Banners und einer Warnmeldung für veraltete Caches.
- Hinzufügen lokalisierter Zeichenketten für den Server-Sync-Status, Cache-Indikatoren und Fallback-Beschriftungen in allen unterstützten Sprachen (de, en, es, fr, zh).

Routinearbeiten:
- Einführung einer Datei `devtools_options.yaml` zur Speicherung von Dart- und Flutter-DevTools-Einstellungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sync status card to the server list that surfaces last update time and data source, with localized messaging and cache-state indicators, plus a DevTools configuration file.

New Features:
- Display a ServerSyncStatusCard above the server list showing last successful update time and whether data is live or from cache.

Enhancements:
- Indicate when server data is served from cache, including a visible banner and stale-cache warning message.
- Add localized strings for server sync status, cache indicators, and fallback labels across supported languages (de, en, es, fr, zh).

Chores:
- Introduce a devtools_options.yaml file to store Dart and Flutter DevTools settings.

</details>

Neue Funktionen:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte Aktualisierungszeit und die Datenquelle (Live vs. Cache) zeigt.

Verbesserungen:
- Deutliche Banner und Hinweise anzeigen, wenn Serverdaten aus dem Cache geliefert werden oder wenn der Cache möglicherweise veraltet ist.
- Lokalisierte Sync-Status-Strings und Fallbacks für alle unterstützten Sprachen (de, en, es, fr, zh) hinzufügen.
- Eine DevTools-Konfigurationsdatei einführen, um Dart- und Flutter-DevTools-Einstellungen zu speichern.

<details>
<summary>Original summary in English</summary>

## Zusammenfassung von Sourcery

Fügt eine Sync-Status-Karte zur Serverliste hinzu, die die letzte Aktualisierungszeit und die Datenquelle anzeigt, mit lokalisierten Meldungen und Cache-Status-Indikatoren sowie einer DevTools-Konfigurationsdatei.

Neue Features:
- Anzeige einer `ServerSyncStatusCard` oberhalb der Serverliste, die die letzte erfolgreiche Aktualisierungszeit und den Hinweis zeigt, ob die Daten live oder aus dem Cache stammen.

Verbesserungen:
- Kennzeichnung, wenn Serverdaten aus dem Cache bereitgestellt werden, einschließlich eines sichtbaren Banners und einer Warnmeldung für veraltete Caches.
- Hinzufügen lokalisierter Zeichenketten für den Server-Sync-Status, Cache-Indikatoren und Fallback-Beschriftungen in allen unterstützten Sprachen (de, en, es, fr, zh).

Routinearbeiten:
- Einführung einer Datei `devtools_options.yaml` zur Speicherung von Dart- und Flutter-DevTools-Einstellungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sync status card to the server list that surfaces last update time and data source, with localized messaging and cache-state indicators, plus a DevTools configuration file.

New Features:
- Display a ServerSyncStatusCard above the server list showing last successful update time and whether data is live or from cache.

Enhancements:
- Indicate when server data is served from cache, including a visible banner and stale-cache warning message.
- Add localized strings for server sync status, cache indicators, and fallback labels across supported languages (de, en, es, fr, zh).

Chores:
- Introduce a devtools_options.yaml file to store Dart and Flutter DevTools settings.

</details>

</details>

</details>

</details>