### PR TITLE
chore(android): migrate app module to built-in Kotlin

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,10 +1,10 @@
 import java.io.FileInputStream
 import java.util.Properties
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
     id("com.google.gms.google-services")
-    id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
 }
 
@@ -24,10 +24,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -58,6 +54,12 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
## Summary
Migrates the Android app module away from the deprecated app-level Kotlin Gradle Plugin setup.

## Changes
- removes app-level `kotlin-android` plugin usage
- migrates JVM target configuration toward built-in Kotlin setup
- keeps Android release build working

## Validation
- `flutter clean`
- `flutter pub get`
- `flutter analyze`
- `flutter build appbundle --release`

Refs #71

## Zusammenfassung von Sourcery

Verbesserungen:
- Ersetzen des App-weiten `kotlin-android`-Plugin-Einsatzes durch den Gradle Kotlin DSL-`kotlin`-Block zur Konfiguration von Compiler-Optionen für das Targeting von JVM 17.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace the app-level `kotlin-android` plugin usage with the Gradle Kotlin DSL `kotlin` block for configuring compiler options targeting JVM 17.

</details>