### PR TITLE
chore(deps): keep stable plugin versions for compatibility work

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -481,10 +481,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_mobile_ads
-      sha256: f35e040875bb54e8a3455bcffed3b4ac9e9263fbf7751b9fd1ae7f30793faee8
+      sha256: "50549f6c945d7a445d53c04f34d025b1a1723fbd02719de9e67de432e2597f40"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "8.0.0"
   graphs:
     dependency: transitive
     description:
@@ -1180,4 +1180,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.1 <4.0.0"
-  flutter: ">=3.38.0"
+  flutter: ">=3.38.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,18 +21,19 @@ dependencies:
 
   dio: ^5.9.2
   equatable: ^2.0.8
-  shared_preferences: ^2.5.3
+  shared_preferences: 2.5.5
 
   intl: ^0.20.2
 
   freezed_annotation: ^3.1.0
   json_annotation: ^4.11.0
 
-  firebase_core: ^4.5.0
-  firebase_auth: ^6.2.0
-  cloud_firestore: ^6.1.3
-  firebase_storage: ^13.2.0
-  google_mobile_ads: ^7.0.0
+  firebase_core: 4.6.0
+  firebase_auth: 6.2.0
+  cloud_firestore: 6.1.3
+  firebase_storage: 13.2.0
+
+  google_mobile_ads: 8.0.0
   url_launcher: ^6.3.2
   flutter_launcher_icons: ^0.14.4
   in_app_purchase: ^3.2.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,10 @@ dependencies:
 
   dio: ^5.9.2
   equatable: ^2.0.8
+
+  # Pinned for current compatibility work:
+  # newer shared_preferences variants still trigger upstream KGP warnings,
+  # but 2.5.5 is part of the currently verified working dependency set.
   shared_preferences: 2.5.5
 
   intl: ^0.20.2
@@ -28,9 +32,15 @@ dependencies:
   freezed_annotation: ^3.1.0
   json_annotation: ^4.11.0
 
+  # Keep FlutterFire on the verified compatible set for now.
+  # Do not bump these independently without revalidating the full stack.
   firebase_core: 4.6.0
   firebase_auth: 6.2.0
   cloud_firestore: 6.1.3
+
+  # Intentionally pinned:
+  # firebase_storage 13.4.1 failed to compile on Android in our current setup,
+  # so we stay on 13.2.0 until the upstream/plugin compatibility issue is resolved.
   firebase_storage: 13.2.0
 
   google_mobile_ads: 8.0.0


### PR DESCRIPTION
## Summary
Keeps the plugin stack on a stable working combination after the built-in Kotlin migration.

## Changes
- keep firebase_storage pinned to 13.2.0 because 13.4.1 fails to compile on Android in the current stack
- keep google_mobile_ads on 8.0.0
- keep shared_preferences on 2.5.5
- preserve the working lockfile combination

## Validation
- flutter pub get
- flutter analyze
- flutter build appbundle --release

## Notes
- app-level built-in Kotlin migration is already completed
- remaining KGP warnings are currently upstream plugin warnings for firebase_storage, shared_preferences_android, and webview_flutter_android

Refs #71

## Zusammenfassung von Sourcery

Flutter-Plugin-Abhängigkeiten auf eine bekannte, stabile Kombination für die aktualisierte Kotlin-Toolchain fixieren und die Lockfile entsprechend aktualisieren.

Verbesserungen:
- Versionen von firebase_core, firebase_auth, cloud_firestore, firebase_storage, google_mobile_ads und shared_preferences auf einen stabilen, explizit festgelegten Satz ausrichten, um Kompatibilität sicherzustellen.

Build:
- Abhängigkeitsversionen in der pubspec aktualisieren und pubspec.lock neu generieren, um den stabilen Plugin-Stack widerzuspiegeln.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Pin Flutter plugin dependencies to a known-good combination for the updated Kotlin toolchain and refresh the lockfile accordingly.

Enhancements:
- Align firebase_core, firebase_auth, cloud_firestore, firebase_storage, google_mobile_ads, and shared_preferences versions to a stable, explicitly pinned set for compatibility.

Build:
- Update pubspec dependency versions and regenerate pubspec.lock to reflect the stable plugin stack.

</details>