### PR TITLE
fix(servers): improve sync status fallback UI and locale-aware date formatting

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -59,7 +59,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_17
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/lib/features/servers/presentation/screens/server_list_screen.dart
+++ b/lib/features/servers/presentation/screens/server_list_screen.dart
@@ -1,4 +1,5 @@
 // features/servers/presentation/screens/server_list_screen.dart
+import 'package:asa_server_eye/features/servers/presentation/widgets/server_sync_status_placeholder_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -41,11 +42,14 @@ class ServerListScreen extends ConsumerWidget {
                   onClear: searchController.clear,
                 ),
                 const SizedBox(height: 8),
-                syncStateAsync.whenOrNull(
-                      data: (syncState) =>
-                          ServerSyncStatusCard(syncState: syncState),
-                    ) ??
-                    const SizedBox.shrink(),
+                syncStateAsync.when(
+                  data: (syncState) =>
+                      ServerSyncStatusCard(syncState: syncState),
+                  loading: () =>
+                      const ServerSyncStatusPlaceholderCard.loading(),
+                  error: (_, _) =>
+                      const ServerSyncStatusPlaceholderCard.error(),
+                ),
               ],
             ),
           ),

--- a/lib/features/servers/presentation/widgets/server_sync_status_card.dart
+++ b/lib/features/servers/presentation/widgets/server_sync_status_card.dart
@@ -89,6 +89,6 @@ class ServerSyncStatusCard extends StatelessWidget {
       alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context),
     );
 
-    return context.l10n.serverSyncLastUpdated('$date, $time');
+    return context.l10n.serverSyncLastUpdated(date, time);
   }
 }

--- a/lib/features/servers/presentation/widgets/server_sync_status_placeholder_card.dart
+++ b/lib/features/servers/presentation/widgets/server_sync_status_placeholder_card.dart
@@ -1,0 +1,44 @@
+// features/servers/presentation/widgets/server_sync_status_placeholder_card.dart
+import 'package:flutter/material.dart';
+
+import '../../../../core/extensions/context_l10n.dart';
+
+class ServerSyncStatusPlaceholderCard extends StatelessWidget {
+  const ServerSyncStatusPlaceholderCard.loading({super.key})
+    : _isLoading = true;
+
+  const ServerSyncStatusPlaceholderCard.error({super.key}) : _isLoading = false;
+
+  final bool _isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            _isLoading
+                ? context.l10n.serverSyncLoading
+                : context.l10n.serverSyncUnavailable,
+            style: theme.textTheme.bodyMedium,
+          ),
+          if (_isLoading) ...[
+            const SizedBox(height: 8),
+            const LinearProgressIndicator(minHeight: 4),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -879,15 +879,6 @@
   "@premiumVerificationQueued": {
     "description": "Hinweis nach dem Übermitteln eines Kauf-Requests"
   },
-  "serverSyncLastUpdated": "Zuletzt aktualisiert: {value}",
-  "@serverSyncLastUpdated": {
-    "description": "Label showing when the server list was last updated",
-    "placeholders": {
-      "value": {
-        "type": "String"
-      }
-    }
-  },
   "serverSyncSourceLive": "Quelle: Live-Daten",
   "@serverSyncSourceLive": {
     "description": "Label showing that server data comes from the network"
@@ -907,5 +898,25 @@
   "serverSyncUnknownUpdateTime": "Zuletzt aktualisiert: Unbekannt",
   "@serverSyncUnknownUpdateTime": {
     "description": "Fallback label when no update time is available"
+  },
+  "serverSyncLastUpdated": "Zuletzt aktualisiert: {date}, {time}",
+  "@serverSyncLastUpdated": {
+    "description": "Label showing when the server list was last updated",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "serverSyncLoading": "Synchronisationsstatus wird geladen …",
+  "@serverSyncLoading": {
+    "description": "Shown while the sync status is still loading"
+  },
+  "serverSyncUnavailable": "Synchronisationsstatus derzeit nicht verfügbar",
+  "@serverSyncUnavailable": {
+    "description": "Shown when sync status could not be loaded"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -879,15 +879,6 @@
   "@premiumVerificationQueued": {
     "description": "Message after purchase verification request was submitted"
   },
-  "serverSyncLastUpdated": "Last updated: {value}",
-  "@serverSyncLastUpdated": {
-    "description": "Label showing when the server list was last updated",
-    "placeholders": {
-      "value": {
-        "type": "String"
-      }
-    }
-  },
   "serverSyncSourceLive": "Source: Live data",
   "@serverSyncSourceLive": {
     "description": "Label showing that server data comes from the network"
@@ -907,5 +898,25 @@
   "serverSyncUnknownUpdateTime": "Last updated: Unknown",
   "@serverSyncUnknownUpdateTime": {
     "description": "Fallback label when no update time is available"
+  },
+  "serverSyncLastUpdated": "Last updated: {date}, {time}",
+  "@serverSyncLastUpdated": {
+    "description": "Label showing when the server list was last updated",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "serverSyncLoading": "Sync status is loading…",
+  "@serverSyncLoading": {
+    "description": "Shown while the sync status is still loading"
+  },
+  "serverSyncUnavailable": "Sync status is currently unavailable",
+  "@serverSyncUnavailable": {
+    "description": "Shown when sync status could not be loaded"
   }
 } 

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -879,33 +879,44 @@
     "@premiumVerificationQueued": {
         "description": "Mensaje después de que se envíe la solicitud de verificación de compra"
     },
-    "serverSyncLastUpdated": "Última actualización: {value}",
-  "@serverSyncLastUpdated": {
-    "description": "Etiqueta para la última vez que se sincronizó con el servidor",
-    "placeholders": {
-      "value": {
-        "type": "String"
-      }
+    "serverSyncSourceLive": "Fuente: Datos en vivo",
+    "@serverSyncSourceLive": {
+        "description": "Etiqueta para indicar que los datos del servidor provienen de la red"
+    },
+    "serverSyncSourceCache": "Fuente: Caché",
+    "@serverSyncSourceCache": {
+        "description": "Etiqueta para indicar que los datos del servidor provienen de la caché"
+    },
+    "serverSyncCacheBanner": "Se están mostrando datos de servidor en caché",
+    "@serverSyncCacheBanner": {
+        "description": "Texto del banner cuando se muestran datos de servidor en caché"
+    },
+    "serverSyncCacheStale": "Los datos en caché podrían estar desactualizados",
+    "@serverSyncCacheStale": {
+        "description": "Sugerencia cuando los datos en caché están desactualizados"
+    },
+    "serverSyncUnknownUpdateTime": "Última actualización: Desconocida",
+    "@serverSyncUnknownUpdateTime": {
+        "description": "Etiqueta para la última vez que se sincronizó con el servidor cuando no se conoce el tiempo de actualización"
+    },
+    "serverSyncLastUpdated": "Última actualización: {date}, {time}",
+    "@serverSyncLastUpdated": {
+        "description": "Label showing when the server list was last updated",
+        "placeholders": {
+            "date": {
+            "type": "String"
+            },
+            "time": {
+            "type": "String"
+            }
+        }
+    },
+    "serverSyncLoading": "Cargando estado de sincronización…",
+    "@serverSyncLoading": {
+        "description": "Shown while the sync status is still loading"
+    },
+    "serverSyncUnavailable": "El estado de sincronización no está disponible en este momento",
+    "@serverSyncUnavailable": {
+        "description": "Shown when sync status could not be loaded"
     }
-  },
-  "serverSyncSourceLive": "Fuente: Datos en vivo",
-  "@serverSyncSourceLive": {
-    "description": "Etiqueta para indicar que los datos del servidor provienen de la red"
-  },
-  "serverSyncSourceCache": "Fuente: Caché",
-  "@serverSyncSourceCache": {
-    "description": "Etiqueta para indicar que los datos del servidor provienen de la caché"
-  },
-  "serverSyncCacheBanner": "Se están mostrando datos de servidor en caché",
-  "@serverSyncCacheBanner": {
-    "description": "Texto del banner cuando se muestran datos de servidor en caché"
-  },
-  "serverSyncCacheStale": "Los datos en caché podrían estar desactualizados",
-  "@serverSyncCacheStale": {
-    "description": "Sugerencia cuando los datos en caché están desactualizados"
-  },
-  "serverSyncUnknownUpdateTime": "Última actualización: Desconocida",
-  "@serverSyncUnknownUpdateTime": {
-    "description": "Etiqueta para la última vez que se sincronizó con el servidor cuando no se conoce el tiempo de actualización"
-  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -879,33 +879,44 @@
     "@premiumVerificationQueued": {
         "description": "Affiché lorsque l'achat de premium est en cours de vérification"
     },
-    "serverSyncLastUpdated": "Dernière mise à jour: {value}",
-  "@serverSyncLastUpdated": {
-    "description": "Libellé de la dernière mise à jour des données du serveur",
-    "placeholders": {
-      "value": {
-        "type": "String"
-      }
+    "serverSyncSourceLive": "Source: Réseau",
+    "@serverSyncSourceLive": {
+        "description": "Libellé indiquant que les données du serveur proviennent du réseau"
+    },
+    "serverSyncSourceCache": "Source: Cache",
+    "@serverSyncSourceCache": {
+        "description": "Libellé indiquant que les données du serveur proviennent de la cache"
+    },
+    "serverSyncCacheBanner": "Les données du serveur en cache sont affichées",
+    "@serverSyncCacheBanner": {
+        "description": "Texte du bandeau lorsque les données du serveur en cache sont affichées"
+    },
+    "serverSyncCacheStale": "Les données en cache pourraient être obsolètes",
+    "@serverSyncCacheStale": {
+        "description": "Indication lorsque les données en cache sont obsolètes"
+    },
+    "serverSyncUnknownUpdateTime": "Dernière mise à jour: Inconnue",
+    "@serverSyncUnknownUpdateTime": {
+        "description": "Libellé de repli lorsque l'heure de mise à jour n'est pas disponible"
+    },
+    "serverSyncLastUpdated": "Dernière mise à jour : {date} à {time}",
+    "@serverSyncLastUpdated": {
+        "description": "Label showing when the server list was last updated",
+        "placeholders": {
+            "date": {
+            "type": "String"
+            },
+            "time": {
+            "type": "String"
+            }
+        }
+    },
+    "serverSyncLoading": "Chargement de l’état de synchronisation…",
+    "@serverSyncLoading": {
+    "description": "Shown while the sync status is still loading"
+    },
+    "serverSyncUnavailable": "L’état de synchronisation est actuellement indisponible",
+    "@serverSyncUnavailable": {
+    "description": "Shown when sync status could not be loaded"
     }
-  },
-  "serverSyncSourceLive": "Source: Réseau",
-  "@serverSyncSourceLive": {
-    "description": "Libellé indiquant que les données du serveur proviennent du réseau"
-  },
-  "serverSyncSourceCache": "Source: Cache",
-  "@serverSyncSourceCache": {
-    "description": "Libellé indiquant que les données du serveur proviennent de la cache"
-  },
-  "serverSyncCacheBanner": "Les données du serveur en cache sont affichées",
-  "@serverSyncCacheBanner": {
-    "description": "Texte du bandeau lorsque les données du serveur en cache sont affichées"
-  },
-  "serverSyncCacheStale": "Les données en cache pourraient être obsolètes",
-  "@serverSyncCacheStale": {
-    "description": "Indication lorsque les données en cache sont obsolètes"
-  },
-  "serverSyncUnknownUpdateTime": "Dernière mise à jour: Inconnue",
-  "@serverSyncUnknownUpdateTime": {
-    "description": "Libellé de repli lorsque l'heure de mise à jour n'est pas disponible"
-  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1337,12 +1337,6 @@ abstract class AppLocalizations {
   /// **'Your purchase was submitted and is now being verified.'**
   String get premiumVerificationQueued;
 
-  /// Label showing when the server list was last updated
-  ///
-  /// In en, this message translates to:
-  /// **'Last updated: {value}'**
-  String serverSyncLastUpdated(String value);
-
   /// Label showing that server data comes from the network
   ///
   /// In en, this message translates to:
@@ -1372,6 +1366,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Last updated: Unknown'**
   String get serverSyncUnknownUpdateTime;
+
+  /// Label showing when the server list was last updated
+  ///
+  /// In en, this message translates to:
+  /// **'Last updated: {date}, {time}'**
+  String serverSyncLastUpdated(String date, String time);
+
+  /// Shown while the sync status is still loading
+  ///
+  /// In en, this message translates to:
+  /// **'Sync status is loading…'**
+  String get serverSyncLoading;
+
+  /// Shown when sync status could not be loaded
+  ///
+  /// In en, this message translates to:
+  /// **'Sync status is currently unavailable'**
+  String get serverSyncUnavailable;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -649,11 +649,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get premiumVerificationQueued => 'Dein Kauf wurde übermittelt und wird jetzt verifiziert.';
 
   @override
-  String serverSyncLastUpdated(String value) {
-    return 'Zuletzt aktualisiert: $value';
-  }
-
-  @override
   String get serverSyncSourceLive => 'Quelle: Live-Daten';
 
   @override
@@ -667,4 +662,15 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => 'Zuletzt aktualisiert: Unbekannt';
+
+  @override
+  String serverSyncLastUpdated(String date, String time) {
+    return 'Zuletzt aktualisiert: $date, $time';
+  }
+
+  @override
+  String get serverSyncLoading => 'Synchronisationsstatus wird geladen …';
+
+  @override
+  String get serverSyncUnavailable => 'Synchronisationsstatus derzeit nicht verfügbar';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -649,11 +649,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get premiumVerificationQueued => 'Your purchase was submitted and is now being verified.';
 
   @override
-  String serverSyncLastUpdated(String value) {
-    return 'Last updated: $value';
-  }
-
-  @override
   String get serverSyncSourceLive => 'Source: Live data';
 
   @override
@@ -667,4 +662,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => 'Last updated: Unknown';
+
+  @override
+  String serverSyncLastUpdated(String date, String time) {
+    return 'Last updated: $date, $time';
+  }
+
+  @override
+  String get serverSyncLoading => 'Sync status is loading…';
+
+  @override
+  String get serverSyncUnavailable => 'Sync status is currently unavailable';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -649,11 +649,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get premiumVerificationQueued => 'Tu compra fue enviada y ahora está siendo verificada.';
 
   @override
-  String serverSyncLastUpdated(String value) {
-    return 'Última actualización: $value';
-  }
-
-  @override
   String get serverSyncSourceLive => 'Fuente: Datos en vivo';
 
   @override
@@ -667,4 +662,15 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => 'Última actualización: Desconocida';
+
+  @override
+  String serverSyncLastUpdated(String date, String time) {
+    return 'Última actualización: $date, $time';
+  }
+
+  @override
+  String get serverSyncLoading => 'Cargando estado de sincronización…';
+
+  @override
+  String get serverSyncUnavailable => 'El estado de sincronización no está disponible en este momento';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -649,11 +649,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get premiumVerificationQueued => 'Votre achat a été soumis et est maintenant en cours de vérification.';
 
   @override
-  String serverSyncLastUpdated(String value) {
-    return 'Dernière mise à jour: $value';
-  }
-
-  @override
   String get serverSyncSourceLive => 'Source: Réseau';
 
   @override
@@ -667,4 +662,15 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => 'Dernière mise à jour: Inconnue';
+
+  @override
+  String serverSyncLastUpdated(String date, String time) {
+    return 'Dernière mise à jour : $date à $time';
+  }
+
+  @override
+  String get serverSyncLoading => 'Chargement de l’état de synchronisation…';
+
+  @override
+  String get serverSyncUnavailable => 'L’état de synchronisation est actuellement indisponible';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -556,73 +556,73 @@ class AppLocalizationsZh extends AppLocalizations {
   String get premiumTitle => 'Premium';
 
   @override
-  String get premiumSettingsSubtitle => 'Unlock and manage premium';
+  String get premiumSettingsSubtitle => '解锁并管理 Premium';
 
   @override
-  String get premiumHeadline => 'Unlock Premium';
+  String get premiumHeadline => '解锁 Premium';
 
   @override
-  String get premiumDescription => 'With Premium, you get access to player sightings, more favorites, and future premium features.';
+  String get premiumDescription => '通过 Premium，你可以访问玩家目击记录、保存更多收藏，并使用未来的高级功能。';
 
   @override
-  String get premiumBenefitSightingsTitle => 'Player sightings';
+  String get premiumBenefitSightingsTitle => '玩家目击记录';
 
   @override
-  String get premiumBenefitSightingsDescription => 'Access sightings directly from the navigation and use premium access across the sightings area.';
+  String get premiumBenefitSightingsDescription => '可直接通过导航访问目击记录，并在整个目击记录区域使用 Premium 权限。';
 
   @override
-  String get premiumBenefitFavoritesTitle => 'More favorites';
+  String get premiumBenefitFavoritesTitle => '更多收藏';
 
   @override
-  String get premiumBenefitFavoritesDescription => 'Save significantly more servers to your favorites.';
+  String get premiumBenefitFavoritesDescription => '可在收藏中保存更多服务器。';
 
   @override
-  String get premiumBenefitAlertsTitle => 'Future extras';
+  String get premiumBenefitAlertsTitle => '未来扩展功能';
 
   @override
-  String get premiumBenefitAlertsDescription => 'Get ready for future premium features like enhanced tracking and alerts.';
+  String get premiumBenefitAlertsDescription => '为即将推出的 Premium 功能做好准备，例如增强监控和提醒。';
 
   @override
-  String get premiumMonthlyPlan => 'Monthly';
+  String get premiumMonthlyPlan => '月度';
 
   @override
-  String get premiumMonthlyPlanDescription => 'Flexible cancellation';
+  String get premiumMonthlyPlanDescription => '可灵活取消';
 
   @override
-  String get premiumYearlyPlan => 'Yearly';
+  String get premiumYearlyPlan => '年度';
 
   @override
-  String get premiumYearlyPlanDescription => 'Best value for long-term use';
+  String get premiumYearlyPlanDescription => '长期使用最划算';
 
   @override
-  String get premiumStartMonthly => 'Start monthly';
+  String get premiumStartMonthly => '开始月度订阅';
 
   @override
-  String get premiumStartYearly => 'Start yearly';
+  String get premiumStartYearly => '开始年度订阅';
 
   @override
-  String get restorePurchases => 'Restore purchases';
+  String get restorePurchases => '恢复购买';
 
   @override
-  String get premiumPurchaseComingSoon => 'The purchase flow will be connected next.';
+  String get premiumPurchaseComingSoon => '购买流程即将接入。';
 
   @override
-  String get premiumUpgradeTitle => 'Upgrade to Premium';
+  String get premiumUpgradeTitle => '升级到 Premium';
 
   @override
-  String get premiumUpgradeDescription => 'Unlock the sightings tab and additional premium benefits.';
+  String get premiumUpgradeDescription => '解锁目击记录标签页和更多 Premium 权益。';
 
   @override
-  String get premiumActiveTitle => 'Premium active';
+  String get premiumActiveTitle => 'Premium 已激活';
 
   @override
-  String get premiumActiveDescription => 'Your account already has access to premium features.';
+  String get premiumActiveDescription => '你的账户已可使用 Premium 功能。';
 
   @override
-  String get unlockPremium => 'Unlock Premium';
+  String get unlockPremium => '解锁 Premium';
 
   @override
-  String get managePremium => 'Manage Premium';
+  String get managePremium => '管理 Premium';
 
   @override
   String get premiumStoreUnavailable => '当前无法连接到商店。';
@@ -649,11 +649,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get premiumVerificationQueued => '您的购买已提交，目前正在验证中。';
 
   @override
-  String serverSyncLastUpdated(String value) {
-    return '最后更新：$value';
-  }
-
-  @override
   String get serverSyncSourceLive => '来源：实时数据';
 
   @override
@@ -667,4 +662,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get serverSyncUnknownUpdateTime => '最后更新：未知';
+
+  @override
+  String serverSyncLastUpdated(String date, String time) {
+    return '最后更新：$date $time';
+  }
+
+  @override
+  String get serverSyncLoading => '正在加载同步状态…';
+
+  @override
+  String get serverSyncUnavailable => '当前无法获取同步状态';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -751,6 +751,102 @@
     "@settingsNavLabel": {
         "description": "底部导航中设置标签的简短文本"
     },
+    "premiumTitle": "Premium",
+    "@premiumTitle": {
+        "description": "Premium 区域标题"
+    },
+    "premiumSettingsSubtitle": "解锁并管理 Premium",
+    "@premiumSettingsSubtitle": {
+      "description": "设置中 Premium 条目的副标题"
+    },
+    "premiumHeadline": "解锁 Premium",
+    "@premiumHeadline": {
+      "description": "Premium 页面主标题"
+    },
+    "premiumDescription": "通过 Premium，你可以访问玩家目击记录、保存更多收藏，并使用未来的高级功能。",
+    "@premiumDescription": {
+      "description": "Premium 功能说明"
+    },
+    "premiumBenefitSightingsTitle": "玩家目击记录",
+    "@premiumBenefitSightingsTitle": {
+      "description": "目击记录权益标题"
+    },
+    "premiumBenefitSightingsDescription": "可直接通过导航访问目击记录，并在整个目击记录区域使用 Premium 权限。",
+    "@premiumBenefitSightingsDescription": {
+      "description": "目击记录权益说明"
+    },
+    "premiumBenefitFavoritesTitle": "更多收藏",
+    "@premiumBenefitFavoritesTitle": {
+      "description": "收藏权益标题"
+    },
+    "premiumBenefitFavoritesDescription": "可在收藏中保存更多服务器。",
+    "@premiumBenefitFavoritesDescription": {
+      "description": "收藏权益说明"
+    },
+    "premiumBenefitAlertsTitle": "未来扩展功能",
+    "@premiumBenefitAlertsTitle": {
+      "description": "未来 Premium 权益标题"
+    },
+    "premiumBenefitAlertsDescription": "为即将推出的 Premium 功能做好准备，例如增强监控和提醒。",
+    "@premiumBenefitAlertsDescription": {
+      "description": "未来 Premium 权益说明"
+    },
+    "premiumMonthlyPlan": "月度",
+    "@premiumMonthlyPlan": {
+      "description": "月度方案"
+    },
+    "premiumMonthlyPlanDescription": "可灵活取消",
+    "@premiumMonthlyPlanDescription": {
+      "description": "月度方案说明"
+    },
+    "premiumYearlyPlan": "年度",
+    "@premiumYearlyPlan": {
+      "description": "年度方案"
+    },
+    "premiumYearlyPlanDescription": "长期使用最划算",
+    "@premiumYearlyPlanDescription": {
+      "description": "年度方案说明"
+    },
+    "premiumStartMonthly": "开始月度订阅",
+    "@premiumStartMonthly": {
+      "description": "月度购买按钮"
+    },
+    "premiumStartYearly": "开始年度订阅",
+    "@premiumStartYearly": {
+      "description": "年度购买按钮"
+    },
+    "restorePurchases": "恢复购买",
+    "@restorePurchases": {
+      "description": "恢复购买按钮"
+    },
+    "premiumPurchaseComingSoon": "购买流程即将接入。",
+    "@premiumPurchaseComingSoon": {
+      "description": "购买流程尚未接入时的提示"
+    },
+    "premiumUpgradeTitle": "升级到 Premium",
+    "@premiumUpgradeTitle": {
+      "description": "个人资料中的 Premium 升级卡片标题"
+    },
+    "premiumUpgradeDescription": "解锁目击记录标签页和更多 Premium 权益。",
+    "@premiumUpgradeDescription": {
+      "description": "个人资料中的 Premium 升级说明"
+    },
+    "premiumActiveTitle": "Premium 已激活",
+    "@premiumActiveTitle": {
+      "description": "Premium 已激活状态标题"
+    },
+    "premiumActiveDescription": "你的账户已可使用 Premium 功能。",
+    "@premiumActiveDescription": {
+      "description": "Premium 已激活状态说明"
+    },
+    "unlockPremium": "解锁 Premium",
+    "@unlockPremium": {
+      "description": "解锁 Premium 按钮"
+    },
+    "managePremium": "管理 Premium",
+    "@managePremium": {
+      "description": "管理 Premium 按钮"
+    },
     "premiumStoreUnavailable": "当前无法连接到商店。",
     "@premiumStoreUnavailable": {
         "description": "当无法连接到商店时显示的错误消息"
@@ -783,15 +879,6 @@
     "@premiumVerificationQueued": {
         "description": "购买验证请求提交后显示的消息"
     },
-    "serverSyncLastUpdated": "最后更新：{value}",
-    "@serverSyncLastUpdated": {
-        "description": "显示服务器列表最后更新时间的标签",
-        "placeholders": {
-            "value": {
-            "type": "String"
-        }
-    }
-    },
     "serverSyncSourceLive": "来源：实时数据",
     "@serverSyncSourceLive": {
     "description": "显示服务器数据来自实时网络的标签"
@@ -811,5 +898,25 @@
     "serverSyncUnknownUpdateTime": "最后更新：未知",
     "@serverSyncUnknownUpdateTime": {
         "description": "当没有可用更新时间时的回退标签"
+    },
+    "serverSyncLastUpdated": "最后更新：{date} {time}",
+    "@serverSyncLastUpdated": {
+        "description": "显示服务器数据最后更新时间的标签",
+        "placeholders": {
+            "date": {
+            "type": "String"
+            },
+            "time": {
+            "type": "String"
+            }
+        }
+    },
+    "serverSyncLoading": "正在加载同步状态…",
+    "@serverSyncLoading": {
+        "description": "正在加载同步状态时显示的标签"
+    },
+    "serverSyncUnavailable": "当前无法获取同步状态",
+    "@serverSyncUnavailable": {
+        "description": "当无法加载同步状态时显示"
     }
 }


### PR DESCRIPTION
## Summary
Improves sync status fallback rendering and makes the last-updated label fully locale-aware.

## Changes
- show a visible loading placeholder while sync status is loading
- show an explicit fallback when sync status is unavailable
- change `serverSyncLastUpdated` to use separate date and time placeholders
- update all supported ARB files
- add the missing 24 Chinese translations required by `flutter gen-l10n`

## Validation
- `flutter gen-l10n`
- `flutter analyze`
- `flutter build appbundle --release`

Closes #72

## Summary by Sourcery

Verbesserung der Benutzeroberfläche für den Server-Synchronisierungsstatus und Lokalisierung des „Zuletzt aktualisiert“-Labels, indem Datum und Uhrzeit getrennt werden.

Neue Funktionen:
- Hinzufügen einer Platzhalter-Karte für den Synchronisierungsstatus, die einen Ladezustand mit Fortschritt sowie eine explizite „nicht verfügbar“-Meldung im Fehlerfall anzeigt.

Verbesserungen:
- Lokalisierung des „Zuletzt aktualisiert“-Labels für die Server-Synchronisierung mit getrennten Parametern für Datum und Uhrzeit für alle unterstützten Gebietsschemata.
- Verfeinerung der chinesischen, Premium-bezogenen Übersetzungen für ein natürlicheres, benutzerorientiertes Erlebnis.
- Anpassung der JVM-Target-Konfiguration des Kotlin-Compilers zur Verwendung der empfohlenen Setter-API.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the server sync status UI and make the last-updated label locale-aware by separating date and time.

New Features:
- Add a placeholder sync status card that shows a loading state with progress and an explicit unavailable message on error.

Enhancements:
- Localize the server sync last-updated label with separate date and time parameters for all supported locales.
- Refine Chinese premium-related translations for a more natural, user-facing experience.
- Adjust Kotlin compiler JVM target configuration to use the recommended setter API.

</details>