### PR TITLE
Feat/77 global alerts tab

### DIFF
--- a/lib/app/presentation/app_shell.dart
+++ b/lib/app/presentation/app_shell.dart
@@ -3,6 +3,7 @@ import 'package:asa_server_eye/core/extensions/context_l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../features/alerts/presentation/screens/alerts_overview_screen.dart';
 import '../../features/favorites/presentation/screens/favorites_screen.dart';
 import '../../features/servers/presentation/screens/server_list_screen.dart';
 import '../../features/settings/presentation/screens/settings_screen.dart';
@@ -53,13 +54,16 @@ class AppShell extends ConsumerWidget {
         ),
       ),
       data: (accessLevel) {
-        final includeSightings =
+        final hasPremiumAccess =
             accessLevel == SightingsAccessLevel.premium ||
             accessLevel == SightingsAccessLevel.admin;
+        final includeAlerts = hasPremiumAccess;
+        final includeSightings = hasPremiumAccess;
 
         final screens = <Widget>[
           const ServerListScreen(),
           const FavoritesScreen(),
+          if (includeAlerts) const AlertsOverviewScreen(),
           if (includeSightings) const SightingsOverviewScreen(),
           const SettingsScreen(),
         ];
@@ -76,6 +80,7 @@ class AppShell extends ConsumerWidget {
           body: IndexedStack(index: safeIndex, children: screens),
           bottomNavigationBar: AppBottomNavigationBar(
             currentIndex: safeIndex,
+            includeAlerts: includeAlerts,
             includeSightings: includeSightings,
             onDestinationSelected: ref
                 .read(appShellIndexProvider.notifier)

--- a/lib/app/presentation/utils/app_navigation_destinations.dart
+++ b/lib/app/presentation/utils/app_navigation_destinations.dart
@@ -1,12 +1,14 @@
 // app/presentation/utils/app_navigation_destinations.dart
 import 'package:flutter/material.dart';
 
+import '../../../features/alerts/presentation/extensions/alert_settings_l10n.dart';
 import '../../../l10n/app_localizations.dart';
 import '../models/app_navigation_destination_item.dart';
 
 abstract final class AppNavigationDestinations {
   static List<AppNavigationDestinationItem> fromL10n(
     AppLocalizations l10n, {
+    required bool includeAlerts,
     required bool includeSightings,
   }) {
     return [
@@ -20,6 +22,12 @@ abstract final class AppNavigationDestinations {
         selectedIcon: Icons.star_rounded,
         label: l10n.favoritesNavLabel,
       ),
+      if (includeAlerts)
+        AppNavigationDestinationItem(
+          icon: Icons.notifications_none_rounded,
+          selectedIcon: Icons.notifications_rounded,
+          label: l10n.alertsNavLabel,
+        ),
       if (includeSightings)
         AppNavigationDestinationItem(
           icon: Icons.visibility_outlined,

--- a/lib/app/presentation/widgets/app_bottom_navigation_bar.dart
+++ b/lib/app/presentation/widgets/app_bottom_navigation_bar.dart
@@ -9,11 +9,13 @@ class AppBottomNavigationBar extends StatelessWidget {
     super.key,
     required this.currentIndex,
     required this.onDestinationSelected,
+    required this.includeAlerts,
     required this.includeSightings,
   });
 
   final int currentIndex;
   final ValueChanged<int> onDestinationSelected;
+  final bool includeAlerts;
   final bool includeSightings;
 
   @override
@@ -21,6 +23,7 @@ class AppBottomNavigationBar extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     final destinations = AppNavigationDestinations.fromL10n(
       l10n,
+      includeAlerts: includeAlerts,
       includeSightings: includeSightings,
     );
 

--- a/lib/features/alerts/presentation/extensions/alert_settings_l10n.dart
+++ b/lib/features/alerts/presentation/extensions/alert_settings_l10n.dart
@@ -4,6 +4,54 @@ import '../../../../l10n/app_localizations.dart';
 extension AlertSettingsL10n on AppLocalizations {
   String get _languageCode => localeName.split('_').first;
 
+  String get alertsNavLabel {
+    switch (_languageCode) {
+      case 'de':
+        return 'Alerts';
+      case 'es':
+        return 'Alertas';
+      case 'fr':
+        return 'Alertes';
+      case 'zh':
+        return '提醒';
+      case 'en':
+      default:
+        return 'Alerts';
+    }
+  }
+
+  String get alertsOverviewTitle {
+    switch (_languageCode) {
+      case 'de':
+        return 'Meine Alerts';
+      case 'es':
+        return 'Mis alertas';
+      case 'fr':
+        return 'Mes alertes';
+      case 'zh':
+        return '我的提醒';
+      case 'en':
+      default:
+        return 'My Alerts';
+    }
+  }
+
+  String get noUserAlertRulesYet {
+    switch (_languageCode) {
+      case 'de':
+        return 'Du hast noch keine Alert-Regeln erstellt.';
+      case 'es':
+        return 'Aún no has creado reglas de alerta.';
+      case 'fr':
+        return 'Vous n’avez pas encore créé de règles d’alerte.';
+      case 'zh':
+        return '你还没有创建提醒规则。';
+      case 'en':
+      default:
+        return 'You have not created any alert rules yet.';
+    }
+  }
+
   String get deleteAllAlertRules {
     switch (_languageCode) {
       case 'de':

--- a/lib/features/alerts/presentation/screens/alerts_overview_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_overview_screen.dart
@@ -87,7 +87,10 @@ class AlertsOverviewScreen extends ConsumerWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Padding(
-                              padding: const EdgeInsets.only(left: 4, bottom: 6),
+                              padding: const EdgeInsets.only(
+                                left: 4,
+                                bottom: 6,
+                              ),
                               child: Text(
                                 '${rule.serverName} • ${rule.mapName}',
                                 style: theme.textTheme.bodySmall?.copyWith(

--- a/lib/features/alerts/presentation/screens/alerts_overview_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_overview_screen.dart
@@ -1,0 +1,272 @@
+// features/alerts/presentation/screens/alerts_overview_screen.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/extensions/context_l10n.dart';
+import '../../domain/entities/alert_rule.dart';
+import '../controllers/alert_rule_mutation_controller.dart';
+import '../extensions/alert_settings_l10n.dart';
+import '../providers/alert_rules_providers.dart';
+import '../widgets/alert_rule_form_sheet.dart';
+import '../widgets/alert_rule_list_tile.dart';
+
+class AlertsOverviewScreen extends ConsumerWidget {
+  const AlertsOverviewScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userId = ref.watch(currentUserIdProvider);
+    final rulesAsync = ref.watch(userAlertRulesProvider);
+    final mutationState = ref.watch(alertRuleMutationControllerProvider);
+    final isMutating = mutationState.isLoading;
+    final theme = Theme.of(context);
+
+    ref.listen<AsyncValue<void>>(alertRuleMutationControllerProvider, (
+      previous,
+      next,
+    ) {
+      next.whenOrNull(
+        error: (_, _) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(context.l10n.alertRuleMutationError)),
+          );
+        },
+      );
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: Text(context.l10n.alertsOverviewTitle)),
+      body: userId == null
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Text(
+                  context.l10n.alertRulesRequiresLogin,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge,
+                ),
+              ),
+            )
+          : AbsorbPointer(
+              absorbing: isMutating,
+              child: rulesAsync.when(
+                data: (rules) {
+                  if (rules.isEmpty) {
+                    return Center(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 24),
+                        child: Text(
+                          context.l10n.noUserAlertRulesYet,
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodyLarge,
+                        ),
+                      ),
+                    );
+                  }
+
+                  return ListView.separated(
+                    padding: const EdgeInsets.all(16),
+                    itemCount: rules.length,
+                    separatorBuilder: (_, _) => const SizedBox(height: 12),
+                    itemBuilder: (context, index) {
+                      final rule = rules[index];
+
+                      return Dismissible(
+                        key: ValueKey(rule.id),
+                        direction: DismissDirection.endToStart,
+                        background: _DeleteRuleSwipeBackground(
+                          label: context.l10n.delete,
+                        ),
+                        confirmDismiss: (_) => _confirmDelete(
+                          context: context,
+                          ref: ref,
+                          userId: userId,
+                          rule: rule,
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.only(left: 4, bottom: 6),
+                              child: Text(
+                                '${rule.serverName} • ${rule.mapName}',
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ),
+                            AlertRuleListTile(
+                              rule: rule,
+                              onEdit: () => _openEditSheet(
+                                context: context,
+                                ref: ref,
+                                userId: userId,
+                                rule: rule,
+                              ),
+                              onDelete: () => _confirmDelete(
+                                context: context,
+                                ref: ref,
+                                userId: userId,
+                                rule: rule,
+                              ),
+                              onEnabledChanged: (value) async {
+                                await ref
+                                    .read(
+                                      alertRuleMutationControllerProvider
+                                          .notifier,
+                                    )
+                                    .setRuleEnabled(
+                                      userId: userId,
+                                      ruleId: rule.id,
+                                      isEnabled: value,
+                                    );
+                                if (!context.mounted) return;
+                                final state = ref.read(
+                                  alertRuleMutationControllerProvider,
+                                );
+                                if (!state.hasError) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        context.l10n.alertRuleUpdated,
+                                      ),
+                                    ),
+                                  );
+                                }
+                              },
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  );
+                },
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (_, _) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    child: Text(
+                      context.l10n.alertRulesLoadError,
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.bodyLarge,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+    );
+  }
+
+  Future<void> _openEditSheet({
+    required BuildContext context,
+    required WidgetRef ref,
+    required String userId,
+    required AlertRule rule,
+  }) async {
+    final updatedRule = await showModalBottomSheet<AlertRule>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => AlertRuleFormSheet(
+        userId: userId,
+        serverId: rule.serverId,
+        serverName: rule.serverName,
+        mapName: rule.mapName,
+        existingRule: rule,
+      ),
+    );
+
+    if (updatedRule == null || !context.mounted) return;
+
+    await ref
+        .read(alertRuleMutationControllerProvider.notifier)
+        .updateRule(updatedRule);
+    if (!context.mounted) return;
+
+    final state = ref.read(alertRuleMutationControllerProvider);
+    if (!state.hasError) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(context.l10n.alertRuleUpdated)));
+    }
+  }
+
+  Future<bool> _confirmDelete({
+    required BuildContext context,
+    required WidgetRef ref,
+    required String userId,
+    required AlertRule rule,
+  }) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(context.l10n.deleteAlertRule),
+          content: Text(context.l10n.deleteAlertRuleQuestion),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: Text(context.l10n.cancel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: Text(context.l10n.delete),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldDelete != true || !context.mounted) return false;
+
+    await ref
+        .read(alertRuleMutationControllerProvider.notifier)
+        .deleteRule(userId: userId, ruleId: rule.id);
+    if (!context.mounted) return false;
+
+    final state = ref.read(alertRuleMutationControllerProvider);
+    if (state.hasError) return false;
+
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(context.l10n.alertRuleDeleted)));
+    return true;
+  }
+}
+
+class _DeleteRuleSwipeBackground extends StatelessWidget {
+  const _DeleteRuleSwipeBackground({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Align(
+        alignment: Alignment.centerRight,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.delete_outline, color: colorScheme.onErrorContainer),
+              const SizedBox(width: 8),
+              Text(
+                label,
+                style: TextStyle(
+                  color: colorScheme.onErrorContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: ARK SA Server Eye – real time server population tracker for ARK S
 
 publish_to: "none"
 
-version: 0.1.5+5
+version: 0.1.6+6
 
 environment:
   sdk: ^3.11.1


### PR DESCRIPTION
## Summary
- Adds a global Alerts tab for users with premium-level access.
- Adds an Alerts overview screen for all current user alert rules.
- Reuses existing alert rule editing, toggling, and removal flows.

Closes #77

## Validation
Please run `dart format lib/app lib/features/alerts` and `flutter analyze` locally.

## Summary by Sourcery

Fügt einen nur für Premium-Nutzer verfügbaren Tab „Benachrichtigungen“ hinzu, mit einer Übersichtsseite, die die Alarmregeln der Nutzer auflistet und die bestehenden Alert-Management-Flows in die Hauptnavigation der App integriert.

Neue Funktionen:
- Einführung eines lokalisierten Navigationsziels „Benachrichtigungen“, das für Nutzer mit Premium- oder Administratorzugang angezeigt wird.
- Hinzufügen einer Übersichtsseite für Benachrichtigungen, die alle Alarmregeln eines Nutzers auflistet und das Bearbeiten, Aktivieren/Deaktivieren und Löschen von Regeln unterstützt, inklusive „Swipe-to-Delete“ und Bestätigungsabläufen.

Verbesserungen:
- Aktualisierung der unteren Navigationsleiste und des Routings, um den Bildschirm „Benachrichtigungen“ abhängig von der Zugriffsebene bedingt einzubinden.
- Erweiterung der Lokalisierungs-Strings für Benachrichtigungen um Bezeichnungen und Leermeldungen (Empty State) für den neuen Tab „Benachrichtigungen“ und die Übersichtsseite.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a premium-only Alerts tab with an overview screen listing user alert rules and integrating existing alert management flows into the main app navigation.

New Features:
- Introduce a localized Alerts navigation destination that is shown for users with premium or admin access.
- Add an Alerts overview screen that lists all user alert rules with support for editing, toggling, and deleting rules, including swipe-to-delete and confirmation flows.

Enhancements:
- Update the bottom navigation shell and routing to conditionally include the Alerts screen based on access level.
- Extend alerts localization strings with labels and empty-state messaging for the new Alerts tab and overview screen.

</details>