### PR TITLE
Feat/79 alert rule evaluation

### DIFF
--- a/lib/app/presentation/app_shell.dart
+++ b/lib/app/presentation/app_shell.dart
@@ -3,8 +3,13 @@ import 'package:asa_server_eye/core/extensions/context_l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../features/alerts/domain/entities/alert_trigger_event.dart';
+import '../../features/alerts/presentation/controllers/alert_evaluation_controller.dart';
+import '../../features/alerts/presentation/extensions/alert_rule_type_l10n.dart';
+import '../../features/alerts/presentation/providers/alert_rules_providers.dart';
 import '../../features/alerts/presentation/screens/alerts_overview_screen.dart';
 import '../../features/favorites/presentation/screens/favorites_screen.dart';
+import '../../features/servers/presentation/providers/servers_provider.dart';
 import '../../features/servers/presentation/screens/server_list_screen.dart';
 import '../../features/settings/presentation/screens/settings_screen.dart';
 import '../../features/sightings/domain/sightings_access_level.dart';
@@ -20,6 +25,33 @@ class AppShell extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final currentIndex = ref.watch(appShellIndexProvider);
     final accessLevelAsync = ref.watch(sightingsAccessLevelProvider);
+
+    ref.listen(serverSyncStateProvider, (previous, next) {
+      final syncState = next.valueOrNull;
+      final rules = ref.read(userAlertRulesProvider).valueOrNull;
+
+      if (syncState == null || rules == null) {
+        return;
+      }
+
+      ref.read(alertEvaluationControllerProvider.notifier).evaluateServerRefresh(
+            rules: rules,
+            currentServers: syncState.servers,
+          );
+    });
+
+    ref.listen<AlertTriggerEvent?>(alertEvaluationControllerProvider, (
+      previous,
+      next,
+    ) {
+      if (next == null || next == previous || !context.mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_alertEventMessage(context, next))),
+      );
+    });
 
     return accessLevelAsync.when(
       loading: () =>
@@ -89,5 +121,16 @@ class AppShell extends ConsumerWidget {
         );
       },
     );
+  }
+
+  String _alertEventMessage(BuildContext context, AlertTriggerEvent event) {
+    final previousPlayers = event.previousPlayers;
+    final currentPlayers = event.currentPlayers;
+    final populationChange = previousPlayers == null || currentPlayers == null
+        ? ''
+        : ' ($previousPlayers → $currentPlayers)';
+
+    return '${event.rule.ruleType.localizedLabel(context)}: '
+        '${event.serverName} • ${event.mapName}$populationChange';
   }
 }

--- a/lib/features/alerts/data/repositories/firestore_alert_rules_repository.dart
+++ b/lib/features/alerts/data/repositories/firestore_alert_rules_repository.dart
@@ -125,6 +125,17 @@ class FirestoreAlertRulesRepository implements AlertRulesRepository {
   }
 
   @override
+  Future<void> markRuleTriggered({
+    required String userId,
+    required String ruleId,
+  }) async {
+    await _rulesCollection(userId).doc(ruleId).update({
+      'lastTriggeredAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  @override
   Future<void> setRuleEnabled({
     required String userId,
     required String ruleId,

--- a/lib/features/alerts/domain/entities/alert_trigger_event.dart
+++ b/lib/features/alerts/domain/entities/alert_trigger_event.dart
@@ -1,0 +1,19 @@
+// features/alerts/domain/entities/alert_trigger_event.dart
+import 'alert_rule.dart';
+
+class AlertTriggerEvent {
+  const AlertTriggerEvent({
+    required this.rule,
+    required this.previousPlayers,
+    required this.currentPlayers,
+    required this.triggeredAt,
+  });
+
+  final AlertRule rule;
+  final int? previousPlayers;
+  final int? currentPlayers;
+  final DateTime triggeredAt;
+
+  String get serverName => rule.serverName;
+  String get mapName => rule.mapName;
+}

--- a/lib/features/alerts/domain/repositories/alert_rules_repository.dart
+++ b/lib/features/alerts/domain/repositories/alert_rules_repository.dart
@@ -20,6 +20,11 @@ abstract class AlertRulesRepository {
     required String serverId,
   });
 
+  Future<void> markRuleTriggered({
+    required String userId,
+    required String ruleId,
+  });
+
   Future<void> setRuleEnabled({
     required String userId,
     required String ruleId,

--- a/lib/features/alerts/domain/services/alert_rule_evaluator.dart
+++ b/lib/features/alerts/domain/services/alert_rule_evaluator.dart
@@ -1,0 +1,100 @@
+// features/alerts/domain/services/alert_rule_evaluator.dart
+import '../../../servers/domain/server.dart';
+import '../entities/alert_rule.dart';
+import '../entities/alert_rule_type.dart';
+import '../entities/alert_trigger_event.dart';
+
+class AlertRuleEvaluator {
+  const AlertRuleEvaluator({
+    this.minimumTriggerInterval = const Duration(minutes: 1),
+  });
+
+  final Duration minimumTriggerInterval;
+
+  List<AlertTriggerEvent> evaluate({
+    required List<AlertRule> rules,
+    required List<Server> previousServers,
+    required List<Server> currentServers,
+    required DateTime now,
+  }) {
+    if (rules.isEmpty || previousServers.isEmpty && currentServers.isEmpty) {
+      return const [];
+    }
+
+    final previousById = _serversById(previousServers);
+    final currentById = _serversById(currentServers);
+    final events = <AlertTriggerEvent>[];
+
+    for (final rule in rules) {
+      if (!rule.isEnabled || _isWithinCooldown(rule, now)) {
+        continue;
+      }
+
+      final previous = previousById[rule.serverId];
+      final current = currentById[rule.serverId];
+
+      if (!_shouldTrigger(rule: rule, previous: previous, current: current)) {
+        continue;
+      }
+
+      events.add(
+        AlertTriggerEvent(
+          rule: rule,
+          previousPlayers: previous?.players,
+          currentPlayers: current?.players,
+          triggeredAt: now,
+        ),
+      );
+    }
+
+    return events;
+  }
+
+  Map<String, Server> _serversById(List<Server> servers) {
+    return {
+      for (final server in servers) server.id: server,
+    };
+  }
+
+  bool _isWithinCooldown(AlertRule rule, DateTime now) {
+    final lastTriggeredAt = rule.lastTriggeredAt;
+    if (lastTriggeredAt == null) {
+      return false;
+    }
+
+    return now.difference(lastTriggeredAt.toUtc()) < minimumTriggerInterval;
+  }
+
+  bool _shouldTrigger({
+    required AlertRule rule,
+    required Server? previous,
+    required Server? current,
+  }) {
+    switch (rule.ruleType) {
+      case AlertRuleType.populationIncreased:
+        return previous != null &&
+            current != null &&
+            current.players > previous.players;
+      case AlertRuleType.populationDecreased:
+        return previous != null &&
+            current != null &&
+            current.players < previous.players;
+      case AlertRuleType.crossedAboveThreshold:
+        final threshold = rule.threshold;
+        if (threshold == null || previous == null || current == null) {
+          return false;
+        }
+        return previous.players <= threshold && current.players > threshold;
+      case AlertRuleType.crossedBelowThreshold:
+        final threshold = rule.threshold;
+        if (threshold == null || previous == null || current == null) {
+          return false;
+        }
+        return previous.players >= threshold && current.players < threshold;
+      case AlertRuleType.serverOnline:
+        return previous == null && current != null;
+      case AlertRuleType.serverOffline:
+        return previous != null && current == null;
+    }
+  }
+}

--- a/lib/features/alerts/presentation/controllers/alert_evaluation_controller.dart
+++ b/lib/features/alerts/presentation/controllers/alert_evaluation_controller.dart
@@ -1,0 +1,88 @@
+// features/alerts/presentation/controllers/alert_evaluation_controller.dart
+import 'dart:developer' as developer;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../servers/domain/server.dart';
+import '../../domain/entities/alert_rule.dart';
+import '../../domain/entities/alert_trigger_event.dart';
+import '../../domain/repositories/alert_rules_repository.dart';
+import '../../domain/services/alert_rule_evaluator.dart';
+import '../providers/alert_rules_providers.dart';
+
+final alertRuleEvaluatorProvider = Provider<AlertRuleEvaluator>((ref) {
+  return const AlertRuleEvaluator();
+});
+
+final alertEvaluationControllerProvider = StateNotifierProvider.autoDispose<
+  AlertEvaluationController,
+  AlertTriggerEvent?
+>((ref) {
+  final repository = ref.watch(alertRulesRepositoryProvider);
+  final evaluator = ref.watch(alertRuleEvaluatorProvider);
+
+  return AlertEvaluationController(
+    repository: repository,
+    evaluator: evaluator,
+  );
+});
+
+class AlertEvaluationController extends StateNotifier<AlertTriggerEvent?> {
+  AlertEvaluationController({
+    required AlertRulesRepository repository,
+    required AlertRuleEvaluator evaluator,
+  })  : _repository = repository,
+        _evaluator = evaluator,
+        super(null);
+
+  final AlertRulesRepository _repository;
+  final AlertRuleEvaluator _evaluator;
+
+  List<Server>? _previousServers;
+  bool _isPersistingTriggers = false;
+
+  Future<void> evaluateServerRefresh({
+    required List<AlertRule> rules,
+    required List<Server> currentServers,
+  }) async {
+    final previousServers = _previousServers;
+    _previousServers = currentServers;
+
+    if (previousServers == null || rules.isEmpty || _isPersistingTriggers) {
+      return;
+    }
+
+    final now = DateTime.now().toUtc();
+    final events = _evaluator.evaluate(
+      rules: rules,
+      previousServers: previousServers,
+      currentServers: currentServers,
+      now: now,
+    );
+
+    if (events.isEmpty) {
+      return;
+    }
+
+    state = events.first;
+
+    _isPersistingTriggers = true;
+    try {
+      for (final event in events) {
+        await _repository.markRuleTriggered(
+          userId: event.rule.userId,
+          ruleId: event.rule.id,
+        );
+      }
+    } catch (error, stackTrace) {
+      developer.log(
+        'Failed to mark alert rules as triggered.',
+        name: 'AlertEvaluationController',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      _isPersistingTriggers = false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add alert rule evaluation for foreground app usage.
- Compare previous and current server populations after refresh.
- Support population increase/decrease, threshold crossing, and online/offline rule types.
- Persist `lastTriggeredAt` when a rule fires to reduce repeated triggers.
- Show the first MVP in-app alert signal as a Snackbar.

Closes #79

## Validation
Please run `dart format lib/app lib/features/alerts` and `flutter analyze` locally.

## Summary by Sourcery

Füge die Auswertung von Warnmeldungen bei Serveraktualisierung im Vordergrund und Benachrichtigungen für Benutzer für Alarmregeln basierend auf Änderungen der Serverauslastung und -verfügbarkeit hinzu.

Neue Funktionen:
- Auswertung von benutzerdefinierten Alarmregeln bei Aktualisierung der Serverliste unter Verwendung der aktuellen und vorherigen Serverauslastung.
- Auslösen von In-App-Benachrichtigungen über Snackbar, wenn eine Alarmregelbedingung erfüllt ist.

Verbesserungen:
- Einführung eines wiederverwendbaren, domänenübergreifenden Alarmregel-Auswerters, der Regeltypen für Auslastungsänderungen, Schwellwertüberschreitungen und Online-/Offline-Status unterstützt.
- Persistieren der Auslösezeitpunkte von Alarmregeln, um einen minimalen Cooldown zwischen wiederholten Warnmeldungen zu erzwingen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add foreground server refresh alert evaluation and user notification for alert rules based on server population and availability changes.

New Features:
- Evaluate user-defined alert rules on server list refresh using current and previous server populations.
- Trigger in-app notifications via Snackbar when an alert rule condition is met.

Enhancements:
- Introduce a reusable domain-level alert rule evaluator supporting population change, threshold crossing, and online/offline rule types.
- Persist alert rule trigger timestamps to enforce a minimum cooldown between repeated alerts.

</details>