### PR TITLE
Feat/81 FCM token registration foundation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     <!-- REQUIRED FOR ADS + FIREBASE -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <!-- REQUIRED FOR ANDROID 13+ NOTIFICATIONS -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <!-- REQUIRED FOR ANDROID 13+ ADS -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 

--- a/lib/app/presentation/app_shell.dart
+++ b/lib/app/presentation/app_shell.dart
@@ -37,7 +37,9 @@ class AppShell extends ConsumerWidget {
         return;
       }
 
-      ref.read(alertEvaluationControllerProvider.notifier).evaluateServerRefresh(
+      ref
+          .read(alertEvaluationControllerProvider.notifier)
+          .evaluateServerRefresh(
             rules: rules,
             currentServers: syncState.servers,
           );

--- a/lib/app/presentation/app_shell.dart
+++ b/lib/app/presentation/app_shell.dart
@@ -9,6 +9,7 @@ import '../../features/alerts/presentation/extensions/alert_rule_type_l10n.dart'
 import '../../features/alerts/presentation/providers/alert_rules_providers.dart';
 import '../../features/alerts/presentation/screens/alerts_overview_screen.dart';
 import '../../features/favorites/presentation/screens/favorites_screen.dart';
+import '../../features/notifications/presentation/controllers/fcm_token_registration_controller.dart';
 import '../../features/servers/presentation/providers/servers_provider.dart';
 import '../../features/servers/presentation/screens/server_list_screen.dart';
 import '../../features/settings/presentation/screens/settings_screen.dart';
@@ -23,6 +24,8 @@ class AppShell extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(fcmTokenRegistrationControllerProvider);
+
     final currentIndex = ref.watch(appShellIndexProvider);
     final accessLevelAsync = ref.watch(sightingsAccessLevelProvider);
 

--- a/lib/features/notifications/data/repositories/fcm_token_repository.dart
+++ b/lib/features/notifications/data/repositories/fcm_token_repository.dart
@@ -22,12 +22,22 @@ class FcmTokenRepository {
       return;
     }
 
-    await _tokensCollection(userId).doc(_tokenDocumentId(normalizedToken)).set({
+    final docRef = _tokensCollection(
+      userId,
+    ).doc(_tokenDocumentId(normalizedToken));
+    final snapshot = await docRef.get();
+
+    final data = <String, dynamic>{
       'token': normalizedToken,
       'platform': defaultTargetPlatform.name,
       'updatedAt': FieldValue.serverTimestamp(),
-      'createdAt': FieldValue.serverTimestamp(),
-    }, SetOptions(merge: true));
+    };
+
+    if (!snapshot.exists) {
+      data['createdAt'] = FieldValue.serverTimestamp();
+    }
+
+    await docRef.set(data, SetOptions(merge: true));
   }
 
   Future<void> removeToken({

--- a/lib/features/notifications/data/repositories/fcm_token_repository.dart
+++ b/lib/features/notifications/data/repositories/fcm_token_repository.dart
@@ -2,6 +2,7 @@
 import 'dart:convert';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:crypto/crypto.dart' show sha256;
 import 'package:flutter/foundation.dart';
 
 class FcmTokenRepository {
@@ -27,7 +28,7 @@ class FcmTokenRepository {
     ).doc(_tokenDocumentId(normalizedToken));
     final updateData = <String, dynamic>{
       'token': normalizedToken,
-      'platform': defaultTargetPlatform.name,
+      'platform': _stablePlatformId,
       'updatedAt': FieldValue.serverTimestamp(),
     };
 
@@ -59,7 +60,24 @@ class FcmTokenRepository {
     ).doc(_tokenDocumentId(normalizedToken)).delete();
   }
 
+  String get _stablePlatformId {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return 'android';
+      case TargetPlatform.iOS:
+        return 'ios';
+      case TargetPlatform.macOS:
+        return 'macos';
+      case TargetPlatform.windows:
+        return 'windows';
+      case TargetPlatform.linux:
+        return 'linux';
+      case TargetPlatform.fuchsia:
+        return 'fuchsia';
+    }
+  }
+
   String _tokenDocumentId(String token) {
-    return base64UrlEncode(utf8.encode(token));
+    return sha256.convert(utf8.encode(token)).toString();
   }
 }

--- a/lib/features/notifications/data/repositories/fcm_token_repository.dart
+++ b/lib/features/notifications/data/repositories/fcm_token_repository.dart
@@ -25,19 +25,24 @@ class FcmTokenRepository {
     final docRef = _tokensCollection(
       userId,
     ).doc(_tokenDocumentId(normalizedToken));
-    final snapshot = await docRef.get();
-
-    final data = <String, dynamic>{
+    final updateData = <String, dynamic>{
       'token': normalizedToken,
       'platform': defaultTargetPlatform.name,
       'updatedAt': FieldValue.serverTimestamp(),
     };
 
-    if (!snapshot.exists) {
-      data['createdAt'] = FieldValue.serverTimestamp();
-    }
+    try {
+      await docRef.update(updateData);
+    } on FirebaseException catch (error) {
+      if (error.code != 'not-found') {
+        rethrow;
+      }
 
-    await docRef.set(data, SetOptions(merge: true));
+      await docRef.set({
+        ...updateData,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+    }
   }
 
   Future<void> removeToken({

--- a/lib/features/notifications/data/repositories/fcm_token_repository.dart
+++ b/lib/features/notifications/data/repositories/fcm_token_repository.dart
@@ -1,0 +1,48 @@
+// features/notifications/data/repositories/fcm_token_repository.dart
+import 'dart:convert';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+class FcmTokenRepository {
+  const FcmTokenRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _tokensCollection(String userId) {
+    return _firestore.collection('users').doc(userId).collection('fcm_tokens');
+  }
+
+  Future<void> saveToken({
+    required String userId,
+    required String token,
+  }) async {
+    final normalizedToken = token.trim();
+    if (normalizedToken.isEmpty) {
+      return;
+    }
+
+    await _tokensCollection(userId).doc(_tokenDocumentId(normalizedToken)).set({
+      'token': normalizedToken,
+      'platform': defaultTargetPlatform.name,
+      'updatedAt': FieldValue.serverTimestamp(),
+      'createdAt': FieldValue.serverTimestamp(),
+    }, SetOptions(merge: true));
+  }
+
+  Future<void> removeToken({
+    required String userId,
+    required String token,
+  }) async {
+    final normalizedToken = token.trim();
+    if (normalizedToken.isEmpty) {
+      return;
+    }
+
+    await _tokensCollection(userId).doc(_tokenDocumentId(normalizedToken)).delete();
+  }
+
+  String _tokenDocumentId(String token) {
+    return base64UrlEncode(utf8.encode(token));
+  }
+}

--- a/lib/features/notifications/data/repositories/fcm_token_repository.dart
+++ b/lib/features/notifications/data/repositories/fcm_token_repository.dart
@@ -39,7 +39,9 @@ class FcmTokenRepository {
       return;
     }
 
-    await _tokensCollection(userId).doc(_tokenDocumentId(normalizedToken)).delete();
+    await _tokensCollection(
+      userId,
+    ).doc(_tokenDocumentId(normalizedToken)).delete();
   }
 
   String _tokenDocumentId(String token) {

--- a/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
+++ b/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
@@ -69,7 +69,6 @@ class FcmTokenRegistrationController {
       }
 
       await handleAuthChange(_ref.read(authStateProvider).valueOrNull);
-      _listenToTokenRefresh();
     } catch (error, stackTrace) {
       developer.log(
         'Failed to retry FCM token registration.',
@@ -120,11 +119,7 @@ class FcmTokenRegistrationController {
 
   Future<void> handleAuthChange(User? user) async {
     if (!_hasNotificationPermission) {
-      _hasNotificationPermission = await _requestPermission();
-
-      if (!_hasNotificationPermission) {
-        return;
-      }
+      return;
     }
 
     final previousUserId = _registeredUserId;

--- a/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
+++ b/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
@@ -40,9 +40,24 @@ class FcmTokenRegistrationController {
     }
 
     _isStarted = true;
+    _listenToTokenRefresh();
 
     try {
       await _configureForegroundPresentation();
+      await retryPermissionAndRegister();
+    } catch (error, stackTrace) {
+      _isStarted = false;
+      developer.log(
+        'Failed to start FCM token registration.',
+        name: 'FcmTokenRegistrationController',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> retryPermissionAndRegister() async {
+    try {
       _hasNotificationPermission = await _requestPermission();
 
       if (!_hasNotificationPermission) {
@@ -57,7 +72,7 @@ class FcmTokenRegistrationController {
       _listenToTokenRefresh();
     } catch (error, stackTrace) {
       developer.log(
-        'Failed to start FCM token registration.',
+        'Failed to retry FCM token registration.',
         name: 'FcmTokenRegistrationController',
         error: error,
         stackTrace: stackTrace,
@@ -66,6 +81,10 @@ class FcmTokenRegistrationController {
   }
 
   void _listenToTokenRefresh() {
+    if (_tokenRefreshSubscription != null) {
+      return;
+    }
+
     _tokenRefreshSubscription = _messaging.onTokenRefresh.listen(
       (token) => _registerTokenForCurrentUser(token),
       onError: (Object error, StackTrace stackTrace) {
@@ -101,7 +120,11 @@ class FcmTokenRegistrationController {
 
   Future<void> handleAuthChange(User? user) async {
     if (!_hasNotificationPermission) {
-      return;
+      _hasNotificationPermission = await _requestPermission();
+
+      if (!_hasNotificationPermission) {
+        return;
+      }
     }
 
     final previousUserId = _registeredUserId;
@@ -131,6 +154,10 @@ class FcmTokenRegistrationController {
       return;
     }
 
+    if (_registeredUserId == user.uid && _registeredToken == token) {
+      return;
+    }
+
     await _saveToken(userId: user.uid, token: token);
   }
 
@@ -144,11 +171,12 @@ class FcmTokenRegistrationController {
       return;
     }
 
+    if (_registeredUserId == user.uid && _registeredToken == token) {
+      return;
+    }
+
     if (_registeredUserId == user.uid && _registeredToken != null) {
-      await _removeRegisteredToken(
-        userId: user.uid,
-        token: _registeredToken!,
-      );
+      await _removeRegisteredToken(userId: user.uid, token: _registeredToken!);
     }
 
     await _saveToken(userId: user.uid, token: token);

--- a/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
+++ b/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
@@ -1,0 +1,103 @@
+// features/notifications/presentation/controllers/fcm_token_registration_controller.dart
+import 'dart:async';
+import 'dart:developer' as developer;
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../auth/presentation/providers/auth_state_provider.dart';
+import '../providers/fcm_token_repository_provider.dart';
+
+final fcmTokenRegistrationControllerProvider =
+    Provider.autoDispose<FcmTokenRegistrationController>((ref) {
+  final controller = FcmTokenRegistrationController(ref);
+  controller.start();
+  ref.onDispose(controller.dispose);
+  return controller;
+});
+
+class FcmTokenRegistrationController {
+  FcmTokenRegistrationController(this._ref);
+
+  final Ref _ref;
+  final FirebaseMessaging _messaging = FirebaseMessaging.instance;
+
+  StreamSubscription<String>? _tokenRefreshSubscription;
+  bool _isStarted = false;
+
+  Future<void> start() async {
+    if (_isStarted) {
+      return;
+    }
+
+    _isStarted = true;
+
+    await _configureForegroundPresentation();
+    await _requestPermission();
+    await _saveCurrentTokenForSignedInUser();
+
+    _tokenRefreshSubscription = _messaging.onTokenRefresh.listen(
+      (token) => _saveTokenForSignedInUser(token),
+      onError: (Object error, StackTrace stackTrace) {
+        developer.log(
+          'FCM token refresh listener failed.',
+          name: 'FcmTokenRegistrationController',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      },
+    );
+  }
+
+  Future<void> _configureForegroundPresentation() async {
+    await _messaging.setForegroundNotificationPresentationOptions(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+  }
+
+  Future<void> _requestPermission() async {
+    await _messaging.requestPermission(
+      alert: true,
+      badge: true,
+      sound: true,
+      provisional: false,
+    );
+  }
+
+  Future<void> _saveCurrentTokenForSignedInUser() async {
+    final token = await _messaging.getToken();
+    if (token == null) {
+      return;
+    }
+
+    await _saveTokenForSignedInUser(token);
+  }
+
+  Future<void> _saveTokenForSignedInUser(String token) async {
+    final user = _ref.read(authStateProvider).valueOrNull;
+    if (user == null) {
+      return;
+    }
+
+    try {
+      await _ref.read(fcmTokenRepositoryProvider).saveToken(
+            userId: user.uid,
+            token: token,
+          );
+    } catch (error, stackTrace) {
+      developer.log(
+        'Failed to save FCM token.',
+        name: 'FcmTokenRegistrationController',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  void dispose() {
+    unawaited(_tokenRefreshSubscription?.cancel());
+    _tokenRefreshSubscription = null;
+  }
+}

--- a/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
+++ b/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
@@ -12,6 +12,11 @@ import '../providers/fcm_token_repository_provider.dart';
 final fcmTokenRegistrationControllerProvider =
     Provider.autoDispose<FcmTokenRegistrationController>((ref) {
       final controller = FcmTokenRegistrationController(ref);
+
+      ref.listen<AsyncValue<User?>>(authStateProvider, (previous, next) {
+        unawaited(controller.handleAuthChange(next.valueOrNull));
+      });
+
       unawaited(controller.start());
       ref.onDispose(controller.dispose);
       return controller;
@@ -48,8 +53,7 @@ class FcmTokenRegistrationController {
         return;
       }
 
-      _listenToAuthChanges();
-      await _registerCurrentTokenForUser(_ref.read(authStateProvider).valueOrNull);
+      await handleAuthChange(_ref.read(authStateProvider).valueOrNull);
       _listenToTokenRefresh();
     } catch (error, stackTrace) {
       developer.log(
@@ -59,12 +63,6 @@ class FcmTokenRegistrationController {
         stackTrace: stackTrace,
       );
     }
-  }
-
-  void _listenToAuthChanges() {
-    _ref.listen<AsyncValue<User?>>(authStateProvider, (previous, next) {
-      unawaited(_handleAuthChange(next.valueOrNull));
-    });
   }
 
   void _listenToTokenRefresh() {
@@ -101,7 +99,7 @@ class FcmTokenRegistrationController {
         settings.authorizationStatus == AuthorizationStatus.provisional;
   }
 
-  Future<void> _handleAuthChange(User? user) async {
+  Future<void> handleAuthChange(User? user) async {
     if (!_hasNotificationPermission) {
       return;
     }

--- a/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
+++ b/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
@@ -10,11 +10,11 @@ import '../providers/fcm_token_repository_provider.dart';
 
 final fcmTokenRegistrationControllerProvider =
     Provider.autoDispose<FcmTokenRegistrationController>((ref) {
-  final controller = FcmTokenRegistrationController(ref);
-  controller.start();
-  ref.onDispose(controller.dispose);
-  return controller;
-});
+      final controller = FcmTokenRegistrationController(ref);
+      controller.start();
+      ref.onDispose(controller.dispose);
+      return controller;
+    });
 
 class FcmTokenRegistrationController {
   FcmTokenRegistrationController(this._ref);
@@ -82,10 +82,9 @@ class FcmTokenRegistrationController {
     }
 
     try {
-      await _ref.read(fcmTokenRepositoryProvider).saveToken(
-            userId: user.uid,
-            token: token,
-          );
+      await _ref
+          .read(fcmTokenRepositoryProvider)
+          .saveToken(userId: user.uid, token: token);
     } catch (error, stackTrace) {
       developer.log(
         'Failed to save FCM token.',

--- a/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
+++ b/lib/features/notifications/presentation/controllers/fcm_token_registration_controller.dart
@@ -2,6 +2,7 @@
 import 'dart:async';
 import 'dart:developer' as developer;
 
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -11,7 +12,7 @@ import '../providers/fcm_token_repository_provider.dart';
 final fcmTokenRegistrationControllerProvider =
     Provider.autoDispose<FcmTokenRegistrationController>((ref) {
       final controller = FcmTokenRegistrationController(ref);
-      controller.start();
+      unawaited(controller.start());
       ref.onDispose(controller.dispose);
       return controller;
     });
@@ -23,6 +24,9 @@ class FcmTokenRegistrationController {
   final FirebaseMessaging _messaging = FirebaseMessaging.instance;
 
   StreamSubscription<String>? _tokenRefreshSubscription;
+  String? _registeredUserId;
+  String? _registeredToken;
+  bool _hasNotificationPermission = false;
   bool _isStarted = false;
 
   Future<void> start() async {
@@ -32,12 +36,40 @@ class FcmTokenRegistrationController {
 
     _isStarted = true;
 
-    await _configureForegroundPresentation();
-    await _requestPermission();
-    await _saveCurrentTokenForSignedInUser();
+    try {
+      await _configureForegroundPresentation();
+      _hasNotificationPermission = await _requestPermission();
 
+      if (!_hasNotificationPermission) {
+        developer.log(
+          'Notification permission not granted. Skipping FCM token registration.',
+          name: 'FcmTokenRegistrationController',
+        );
+        return;
+      }
+
+      _listenToAuthChanges();
+      await _registerCurrentTokenForUser(_ref.read(authStateProvider).valueOrNull);
+      _listenToTokenRefresh();
+    } catch (error, stackTrace) {
+      developer.log(
+        'Failed to start FCM token registration.',
+        name: 'FcmTokenRegistrationController',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  void _listenToAuthChanges() {
+    _ref.listen<AsyncValue<User?>>(authStateProvider, (previous, next) {
+      unawaited(_handleAuthChange(next.valueOrNull));
+    });
+  }
+
+  void _listenToTokenRefresh() {
     _tokenRefreshSubscription = _messaging.onTokenRefresh.listen(
-      (token) => _saveTokenForSignedInUser(token),
+      (token) => _registerTokenForCurrentUser(token),
       onError: (Object error, StackTrace stackTrace) {
         developer.log(
           'FCM token refresh listener failed.',
@@ -57,37 +89,104 @@ class FcmTokenRegistrationController {
     );
   }
 
-  Future<void> _requestPermission() async {
-    await _messaging.requestPermission(
+  Future<bool> _requestPermission() async {
+    final settings = await _messaging.requestPermission(
       alert: true,
       badge: true,
       sound: true,
       provisional: false,
     );
+
+    return settings.authorizationStatus == AuthorizationStatus.authorized ||
+        settings.authorizationStatus == AuthorizationStatus.provisional;
   }
 
-  Future<void> _saveCurrentTokenForSignedInUser() async {
+  Future<void> _handleAuthChange(User? user) async {
+    if (!_hasNotificationPermission) {
+      return;
+    }
+
+    final previousUserId = _registeredUserId;
+    final previousToken = _registeredToken;
+
+    if (previousUserId != null &&
+        previousToken != null &&
+        previousUserId != user?.uid) {
+      await _removeRegisteredToken(
+        userId: previousUserId,
+        token: previousToken,
+      );
+      _registeredUserId = null;
+      _registeredToken = null;
+    }
+
+    await _registerCurrentTokenForUser(user);
+  }
+
+  Future<void> _registerCurrentTokenForUser(User? user) async {
+    if (user == null) {
+      return;
+    }
+
     final token = await _messaging.getToken();
     if (token == null) {
       return;
     }
 
-    await _saveTokenForSignedInUser(token);
+    await _saveToken(userId: user.uid, token: token);
   }
 
-  Future<void> _saveTokenForSignedInUser(String token) async {
+  Future<void> _registerTokenForCurrentUser(String token) async {
+    if (!_hasNotificationPermission) {
+      return;
+    }
+
     final user = _ref.read(authStateProvider).valueOrNull;
     if (user == null) {
       return;
     }
 
+    if (_registeredUserId == user.uid && _registeredToken != null) {
+      await _removeRegisteredToken(
+        userId: user.uid,
+        token: _registeredToken!,
+      );
+    }
+
+    await _saveToken(userId: user.uid, token: token);
+  }
+
+  Future<void> _saveToken({
+    required String userId,
+    required String token,
+  }) async {
     try {
       await _ref
           .read(fcmTokenRepositoryProvider)
-          .saveToken(userId: user.uid, token: token);
+          .saveToken(userId: userId, token: token);
+      _registeredUserId = userId;
+      _registeredToken = token;
     } catch (error, stackTrace) {
       developer.log(
         'Failed to save FCM token.',
+        name: 'FcmTokenRegistrationController',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _removeRegisteredToken({
+    required String userId,
+    required String token,
+  }) async {
+    try {
+      await _ref
+          .read(fcmTokenRepositoryProvider)
+          .removeToken(userId: userId, token: token);
+    } catch (error, stackTrace) {
+      developer.log(
+        'Failed to remove FCM token.',
         name: 'FcmTokenRegistrationController',
         error: error,
         stackTrace: stackTrace,

--- a/lib/features/notifications/presentation/providers/fcm_token_repository_provider.dart
+++ b/lib/features/notifications/presentation/providers/fcm_token_repository_provider.dart
@@ -1,0 +1,9 @@
+// features/notifications/presentation/providers/fcm_token_repository_provider.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/repositories/fcm_token_repository.dart';
+
+final fcmTokenRepositoryProvider = Provider<FcmTokenRepository>((ref) {
+  return FcmTokenRepository(FirebaseFirestore.instance);
+});

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import cloud_firestore
 import file_selector_macos
 import firebase_auth
 import firebase_core
+import firebase_messaging
 import firebase_storage
 import in_app_purchase_storekit
 import shared_preferences_foundation
@@ -20,6 +21,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -361,6 +361,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.5.1"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: "8dc372085b1647f05e3ec1b8bc1dada87c0062f93b2a6976f620eb85edc44f97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.1.3"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: "6ea10f7df747542b17679d5939213c09163aab9c301b2f9b858cb55f38efdb54"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.8"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: "1f9798c8021ccf22b7e43e7fba81becd42252cb168228379fcabb7c2ef7dd638"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.4"
   firebase_storage:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,9 @@ dependencies:
   firebase_core: 4.6.0
   firebase_auth: 6.2.0
   cloud_firestore: 6.1.3
-  firebase_messaging: 16.2.2
+  # Keep below 16.2.2 while firebase_storage stays pinned to 13.2.0,
+  # because firebase_messaging 16.2.2+ requires a newer firebase_core_platform_interface.
+  firebase_messaging: 16.1.3
 
   # Intentionally pinned:
   # firebase_storage 13.4.1 failed to compile on Android in our current setup,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   firebase_core: 4.6.0
   firebase_auth: 6.2.0
   cloud_firestore: 6.1.3
+  firebase_messaging: 16.2.2
 
   # Intentionally pinned:
   # firebase_storage 13.4.1 failed to compile on Android in our current setup,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
 
   dio: ^5.9.2
   equatable: ^2.0.8
+  crypto: ^3.0.7
 
   # Pinned for current compatibility work:
   # newer shared_preferences variants still trigger upstream KGP warnings,


### PR DESCRIPTION
## Summary
- Add Firebase Messaging dependency.
- Add Android 13+ notification permission.
- Add FCM token repository storing tokens per user device.
- Add token registration controller with permission request and token refresh handling.
- Start token registration from the app shell.

Refs #81

## Notes
This is the client foundation for background push notifications. Server-side Cloud Functions / scheduler logic should follow in a separate PR.

## Validation
Please run `flutter pub get`, `dart format lib/app lib/features/notifications`, and `flutter analyze` locally.

## Zusammenfassung von Sourcery

Einführung der Client-seitigen Infrastruktur für die Verarbeitung und Registrierung von FCM-Tokens, die an authentifizierte Benutzer gebunden ist.

Neue Funktionen:
- Hinzufügen eines FCM-Token-Registrierungscontrollers, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den angemeldeten Benutzer speichert.
- Speichern von FCM-Tokens pro Benutzer und Gerät in Firestore über ein neues Repository und einen neuen Provider.
- Starten der FCM-Token-Registrierung aus der App-Shell beim App-Start.

Verbesserungen:
- Hinzufügen der Benachrichtigungsberechtigungserklärung für Android 13+ und der Firebase-Messaging-Abhängigkeit zur Unterstützung von Push-Benachrichtigungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clientseitige Infrastruktur einführen, um FCM-Tokens für authentifizierte Nutzer zu registrieren und zu verwalten und sie in den App-Startprozess einzubinden.

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Nutzer registriert oder aktualisiert, einschließlich Reaktion auf Authentifizierungsänderungen und Token-Refresh-Ereignisse.
- FCM-Tokens pro Nutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistent speichern.
- Die Registrierung von FCM-Tokens automatisch aus dem App-Shell anstoßen, wenn die App aufgebaut wird.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das zugehörige macOS-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.
- Die `crypto`-Abhängigkeit hinzufügen, um das Hashing von FCM-Tokens für Dokument-IDs in Firestore zu unterstützen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce client-side infrastructure to register and manage FCM tokens for authenticated users and wire it into app startup.

New Features:
- Add an FCM token registration controller that requests notification permissions, configures foreground presentation, and registers or updates tokens for the current user, including reacting to auth changes and token refresh events.
- Persist FCM tokens per user and device in Firestore via a dedicated repository and Riverpod provider.
- Trigger FCM token registration automatically from the app shell when the app is built.

Enhancements:
- Integrate the Firebase Messaging dependency and register its macOS plugin to enable push notification handling.

Build:
- Declare the Android 13+ POST_NOTIFICATIONS permission in the Android manifest to allow notifications on recent Android versions.
- Add the crypto dependency to support hashing of FCM tokens for document IDs in Firestore.

</details>

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung von Benachrichtigungen im Vordergrund konfiguriert und Tokens für den aktuellen Benutzer registriert oder aktualisiert, einschließlich der Behandlung von Token-Aktualisierungen und Authentifizierungsänderungen.
- FCM-Tokens pro Benutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistieren.
- Die FCM-Token-Registrierung automatisch aus dem App-Shell während des App-Starts auslösen.

Verbesserungen:
- Die Firebase Messaging-Abhängigkeit integrieren und das macOS-Messaging-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clientseitige Infrastruktur einführen, um FCM-Tokens für authentifizierte Nutzer zu registrieren und zu verwalten und sie in den App-Startprozess einzubinden.

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Nutzer registriert oder aktualisiert, einschließlich Reaktion auf Authentifizierungsänderungen und Token-Refresh-Ereignisse.
- FCM-Tokens pro Nutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistent speichern.
- Die Registrierung von FCM-Tokens automatisch aus dem App-Shell anstoßen, wenn die App aufgebaut wird.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das zugehörige macOS-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.
- Die `crypto`-Abhängigkeit hinzufügen, um das Hashing von FCM-Tokens für Dokument-IDs in Firestore zu unterstützen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce client-side infrastructure to register and manage FCM tokens for authenticated users and wire it into app startup.

New Features:
- Add an FCM token registration controller that requests notification permissions, configures foreground presentation, and registers or updates tokens for the current user, including reacting to auth changes and token refresh events.
- Persist FCM tokens per user and device in Firestore via a dedicated repository and Riverpod provider.
- Trigger FCM token registration automatically from the app shell when the app is built.

Enhancements:
- Integrate the Firebase Messaging dependency and register its macOS plugin to enable push notification handling.

Build:
- Declare the Android 13+ POST_NOTIFICATIONS permission in the Android manifest to allow notifications on recent Android versions.
- Add the crypto dependency to support hashing of FCM tokens for document IDs in Firestore.

</details>

</details>

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Benutzer registriert.
- FCM-Tokens pro Benutzer und Gerät in Firestore über ein dediziertes Repository und einen Provider persistent speichern.
- Die Registrierung von FCM-Tokens beim Start aus dem App-Shell heraus auslösen.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das Messaging-Plugin für macOS registrieren, um Push-Benachrichtigungen zu unterstützen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu aktivieren.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clientseitige Infrastruktur einführen, um FCM-Tokens für authentifizierte Nutzer zu registrieren und zu verwalten und sie in den App-Startprozess einzubinden.

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Nutzer registriert oder aktualisiert, einschließlich Reaktion auf Authentifizierungsänderungen und Token-Refresh-Ereignisse.
- FCM-Tokens pro Nutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistent speichern.
- Die Registrierung von FCM-Tokens automatisch aus dem App-Shell anstoßen, wenn die App aufgebaut wird.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das zugehörige macOS-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.
- Die `crypto`-Abhängigkeit hinzufügen, um das Hashing von FCM-Tokens für Dokument-IDs in Firestore zu unterstützen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce client-side infrastructure to register and manage FCM tokens for authenticated users and wire it into app startup.

New Features:
- Add an FCM token registration controller that requests notification permissions, configures foreground presentation, and registers or updates tokens for the current user, including reacting to auth changes and token refresh events.
- Persist FCM tokens per user and device in Firestore via a dedicated repository and Riverpod provider.
- Trigger FCM token registration automatically from the app shell when the app is built.

Enhancements:
- Integrate the Firebase Messaging dependency and register its macOS plugin to enable push notification handling.

Build:
- Declare the Android 13+ POST_NOTIFICATIONS permission in the Android manifest to allow notifications on recent Android versions.
- Add the crypto dependency to support hashing of FCM tokens for document IDs in Firestore.

</details>

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung von Benachrichtigungen im Vordergrund konfiguriert und Tokens für den aktuellen Benutzer registriert oder aktualisiert, einschließlich der Behandlung von Token-Aktualisierungen und Authentifizierungsänderungen.
- FCM-Tokens pro Benutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistieren.
- Die FCM-Token-Registrierung automatisch aus dem App-Shell während des App-Starts auslösen.

Verbesserungen:
- Die Firebase Messaging-Abhängigkeit integrieren und das macOS-Messaging-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clientseitige Infrastruktur einführen, um FCM-Tokens für authentifizierte Nutzer zu registrieren und zu verwalten und sie in den App-Startprozess einzubinden.

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Nutzer registriert oder aktualisiert, einschließlich Reaktion auf Authentifizierungsänderungen und Token-Refresh-Ereignisse.
- FCM-Tokens pro Nutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistent speichern.
- Die Registrierung von FCM-Tokens automatisch aus dem App-Shell anstoßen, wenn die App aufgebaut wird.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das zugehörige macOS-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.
- Die `crypto`-Abhängigkeit hinzufügen, um das Hashing von FCM-Tokens für Dokument-IDs in Firestore zu unterstützen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce client-side infrastructure to register and manage FCM tokens for authenticated users and wire it into app startup.

New Features:
- Add an FCM token registration controller that requests notification permissions, configures foreground presentation, and registers or updates tokens for the current user, including reacting to auth changes and token refresh events.
- Persist FCM tokens per user and device in Firestore via a dedicated repository and Riverpod provider.
- Trigger FCM token registration automatically from the app shell when the app is built.

Enhancements:
- Integrate the Firebase Messaging dependency and register its macOS plugin to enable push notification handling.

Build:
- Declare the Android 13+ POST_NOTIFICATIONS permission in the Android manifest to allow notifications on recent Android versions.
- Add the crypto dependency to support hashing of FCM tokens for document IDs in Firestore.

</details>

</details>

</details>

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und die Token-Aktualisierung für die aktuelle Nutzer:in verarbeitet.
- FCM-Tokens pro Nutzer:in und Gerät in Firestore über ein dediziertes Repository und einen Provider persistent speichern.
- Die FCM-Token-Registrierung automatisch starten, wenn das App-Shell aufgebaut wird.

Verbesserungen:
- Firebase Messaging als Abhängigkeit hinzufügen und das Messaging-Plugin für macOS registrieren, um Push-Benachrichtigungen zu unterstützen.
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clientseitige Infrastruktur einführen, um FCM-Tokens für authentifizierte Nutzer zu registrieren und zu verwalten und sie in den App-Startprozess einzubinden.

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Nutzer registriert oder aktualisiert, einschließlich Reaktion auf Authentifizierungsänderungen und Token-Refresh-Ereignisse.
- FCM-Tokens pro Nutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistent speichern.
- Die Registrierung von FCM-Tokens automatisch aus dem App-Shell anstoßen, wenn die App aufgebaut wird.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das zugehörige macOS-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.
- Die `crypto`-Abhängigkeit hinzufügen, um das Hashing von FCM-Tokens für Dokument-IDs in Firestore zu unterstützen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce client-side infrastructure to register and manage FCM tokens for authenticated users and wire it into app startup.

New Features:
- Add an FCM token registration controller that requests notification permissions, configures foreground presentation, and registers or updates tokens for the current user, including reacting to auth changes and token refresh events.
- Persist FCM tokens per user and device in Firestore via a dedicated repository and Riverpod provider.
- Trigger FCM token registration automatically from the app shell when the app is built.

Enhancements:
- Integrate the Firebase Messaging dependency and register its macOS plugin to enable push notification handling.

Build:
- Declare the Android 13+ POST_NOTIFICATIONS permission in the Android manifest to allow notifications on recent Android versions.
- Add the crypto dependency to support hashing of FCM tokens for document IDs in Firestore.

</details>

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung von Benachrichtigungen im Vordergrund konfiguriert und Tokens für den aktuellen Benutzer registriert oder aktualisiert, einschließlich der Behandlung von Token-Aktualisierungen und Authentifizierungsänderungen.
- FCM-Tokens pro Benutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistieren.
- Die FCM-Token-Registrierung automatisch aus dem App-Shell während des App-Starts auslösen.

Verbesserungen:
- Die Firebase Messaging-Abhängigkeit integrieren und das macOS-Messaging-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clientseitige Infrastruktur einführen, um FCM-Tokens für authentifizierte Nutzer zu registrieren und zu verwalten und sie in den App-Startprozess einzubinden.

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Nutzer registriert oder aktualisiert, einschließlich Reaktion auf Authentifizierungsänderungen und Token-Refresh-Ereignisse.
- FCM-Tokens pro Nutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistent speichern.
- Die Registrierung von FCM-Tokens automatisch aus dem App-Shell anstoßen, wenn die App aufgebaut wird.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das zugehörige macOS-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.
- Die `crypto`-Abhängigkeit hinzufügen, um das Hashing von FCM-Tokens für Dokument-IDs in Firestore zu unterstützen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce client-side infrastructure to register and manage FCM tokens for authenticated users and wire it into app startup.

New Features:
- Add an FCM token registration controller that requests notification permissions, configures foreground presentation, and registers or updates tokens for the current user, including reacting to auth changes and token refresh events.
- Persist FCM tokens per user and device in Firestore via a dedicated repository and Riverpod provider.
- Trigger FCM token registration automatically from the app shell when the app is built.

Enhancements:
- Integrate the Firebase Messaging dependency and register its macOS plugin to enable push notification handling.

Build:
- Declare the Android 13+ POST_NOTIFICATIONS permission in the Android manifest to allow notifications on recent Android versions.
- Add the crypto dependency to support hashing of FCM tokens for document IDs in Firestore.

</details>

</details>

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Benutzer registriert.
- FCM-Tokens pro Benutzer und Gerät in Firestore über ein dediziertes Repository und einen Provider persistent speichern.
- Die Registrierung von FCM-Tokens beim Start aus dem App-Shell heraus auslösen.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das Messaging-Plugin für macOS registrieren, um Push-Benachrichtigungen zu unterstützen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu aktivieren.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clientseitige Infrastruktur einführen, um FCM-Tokens für authentifizierte Nutzer zu registrieren und zu verwalten und sie in den App-Startprozess einzubinden.

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Nutzer registriert oder aktualisiert, einschließlich Reaktion auf Authentifizierungsänderungen und Token-Refresh-Ereignisse.
- FCM-Tokens pro Nutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistent speichern.
- Die Registrierung von FCM-Tokens automatisch aus dem App-Shell anstoßen, wenn die App aufgebaut wird.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das zugehörige macOS-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.
- Die `crypto`-Abhängigkeit hinzufügen, um das Hashing von FCM-Tokens für Dokument-IDs in Firestore zu unterstützen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce client-side infrastructure to register and manage FCM tokens for authenticated users and wire it into app startup.

New Features:
- Add an FCM token registration controller that requests notification permissions, configures foreground presentation, and registers or updates tokens for the current user, including reacting to auth changes and token refresh events.
- Persist FCM tokens per user and device in Firestore via a dedicated repository and Riverpod provider.
- Trigger FCM token registration automatically from the app shell when the app is built.

Enhancements:
- Integrate the Firebase Messaging dependency and register its macOS plugin to enable push notification handling.

Build:
- Declare the Android 13+ POST_NOTIFICATIONS permission in the Android manifest to allow notifications on recent Android versions.
- Add the crypto dependency to support hashing of FCM tokens for document IDs in Firestore.

</details>

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung von Benachrichtigungen im Vordergrund konfiguriert und Tokens für den aktuellen Benutzer registriert oder aktualisiert, einschließlich der Behandlung von Token-Aktualisierungen und Authentifizierungsänderungen.
- FCM-Tokens pro Benutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistieren.
- Die FCM-Token-Registrierung automatisch aus dem App-Shell während des App-Starts auslösen.

Verbesserungen:
- Die Firebase Messaging-Abhängigkeit integrieren und das macOS-Messaging-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clientseitige Infrastruktur einführen, um FCM-Tokens für authentifizierte Nutzer zu registrieren und zu verwalten und sie in den App-Startprozess einzubinden.

Neue Features:
- Einen FCM-Token-Registrierungscontroller hinzufügen, der Benachrichtigungsberechtigungen anfordert, die Darstellung im Vordergrund konfiguriert und Tokens für den aktuellen Nutzer registriert oder aktualisiert, einschließlich Reaktion auf Authentifizierungsänderungen und Token-Refresh-Ereignisse.
- FCM-Tokens pro Nutzer und Gerät in Firestore über ein dediziertes Repository und einen Riverpod-Provider persistent speichern.
- Die Registrierung von FCM-Tokens automatisch aus dem App-Shell anstoßen, wenn die App aufgebaut wird.

Verbesserungen:
- Die Firebase-Messaging-Abhängigkeit integrieren und das zugehörige macOS-Plugin registrieren, um die Verarbeitung von Push-Benachrichtigungen zu ermöglichen.

Build:
- Die Android-13+-Berechtigung `POST_NOTIFICATIONS` im Android-Manifest deklarieren, um Benachrichtigungen auf aktuellen Android-Versionen zu erlauben.
- Die `crypto`-Abhängigkeit hinzufügen, um das Hashing von FCM-Tokens für Dokument-IDs in Firestore zu unterstützen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce client-side infrastructure to register and manage FCM tokens for authenticated users and wire it into app startup.

New Features:
- Add an FCM token registration controller that requests notification permissions, configures foreground presentation, and registers or updates tokens for the current user, including reacting to auth changes and token refresh events.
- Persist FCM tokens per user and device in Firestore via a dedicated repository and Riverpod provider.
- Trigger FCM token registration automatically from the app shell when the app is built.

Enhancements:
- Integrate the Firebase Messaging dependency and register its macOS plugin to enable push notification handling.

Build:
- Declare the Android 13+ POST_NOTIFICATIONS permission in the Android manifest to allow notifications on recent Android versions.
- Add the crypto dependency to support hashing of FCM tokens for document IDs in Firestore.

</details>

</details>

</details>

</details>

</details>