### PR TITLE
Fix alert evaluation review feedback

### DIFF
--- a/lib/features/alerts/domain/services/alert_rule_evaluator.dart
+++ b/lib/features/alerts/domain/services/alert_rule_evaluator.dart
@@ -17,7 +17,7 @@ class AlertRuleEvaluator {
     required List<Server> currentServers,
     required DateTime now,
   }) {
-    if (rules.isEmpty || previousServers.isEmpty && currentServers.isEmpty) {
+    if (rules.isEmpty || (previousServers.isEmpty && currentServers.isEmpty)) {
       return const [];
     }
 

--- a/lib/features/alerts/presentation/controllers/alert_evaluation_controller.dart
+++ b/lib/features/alerts/presentation/controllers/alert_evaluation_controller.dart
@@ -1,4 +1,5 @@
 // features/alerts/presentation/controllers/alert_evaluation_controller.dart
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -39,7 +40,7 @@ class AlertEvaluationController extends StateNotifier<AlertTriggerEvent?> {
   final AlertRuleEvaluator _evaluator;
 
   List<Server>? _previousServers;
-  bool _isPersistingTriggers = false;
+  final Set<String> _pendingTriggerPersistenceRuleIds = <String>{};
 
   Future<void> evaluateServerRefresh({
     required List<AlertRule> rules,
@@ -48,7 +49,7 @@ class AlertEvaluationController extends StateNotifier<AlertTriggerEvent?> {
     final previousServers = _previousServers;
     _previousServers = currentServers;
 
-    if (previousServers == null || rules.isEmpty || _isPersistingTriggers) {
+    if (previousServers == null || rules.isEmpty) {
       return;
     }
 
@@ -60,29 +61,44 @@ class AlertEvaluationController extends StateNotifier<AlertTriggerEvent?> {
       now: now,
     );
 
-    if (events.isEmpty) {
+    final newEvents = events
+        .where(
+          (event) =>
+              !_pendingTriggerPersistenceRuleIds.contains(event.rule.id),
+        )
+        .toList();
+
+    if (newEvents.isEmpty) {
       return;
     }
 
-    state = events.first;
+    state = newEvents.first;
 
-    _isPersistingTriggers = true;
-    try {
-      for (final event in events) {
-        await _repository.markRuleTriggered(
-          userId: event.rule.userId,
-          ruleId: event.rule.id,
-        );
-      }
-    } catch (error, stackTrace) {
-      developer.log(
-        'Failed to mark alert rules as triggered.',
-        name: 'AlertEvaluationController',
-        error: error,
-        stackTrace: stackTrace,
-      );
-    } finally {
-      _isPersistingTriggers = false;
+    for (final event in newEvents) {
+      _persistTriggerInBackground(event);
     }
+  }
+
+  void _persistTriggerInBackground(AlertTriggerEvent event) {
+    final ruleId = event.rule.id;
+    _pendingTriggerPersistenceRuleIds.add(ruleId);
+
+    unawaited(
+      _repository
+          .markRuleTriggered(
+            userId: event.rule.userId,
+            ruleId: ruleId,
+          )
+          .catchError((Object error, StackTrace stackTrace) {
+        developer.log(
+          'Failed to mark alert rule as triggered.',
+          name: 'AlertEvaluationController',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }).whenComplete(() {
+        _pendingTriggerPersistenceRuleIds.remove(ruleId);
+      }),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Address follow-up review feedback from PR #80.
- Add explicit parentheses to the alert evaluator early-return condition.
- Avoid dropping full server refresh evaluations while trigger timestamps are being persisted.
- Persist triggered rule timestamps in the background while deduplicating pending rule IDs.

## Validation
Please run `dart format lib/features/alerts` and `flutter analyze` locally.

## Zusammenfassung von Sourcery

Verfeinerung des Alert-Auswertungsverhaltens, um zu vermeiden, dass Auswertungen während der Trigger-Persistierung übersprungen werden, und um die Bedingungen für die Regelbewertung zu präzisieren.

Fehlerbehebungen:
- Verhindern, dass Auswertungen bei vollständigen Serveraktualisierungen verworfen werden, während Zeitstempel ausgelöster Regeln persistiert werden.
- Regeln mit ausstehender Trigger-Persistierung von der Generierung doppelter Alert-Trigger-Ereignisse ausschließen.
- Die vorzeitige Rückgabebedingung des Evaluators klären, indem explizite Klammern um die Prüfung auf leere Serverliste hinzugefügt werden.

Verbesserungen:
- Zeitstempel ausgelöster Regeln asynchron im Hintergrund persistieren, um die Alert-Auswertung von der Persistenzlatenz zu entkoppeln.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Verfeinerung der Alarmbewertung, um zu vermeiden, dass Auswertungen während der Trigger-Persistierung übersprungen werden, und um die Bedingungen für die Regelbewertung zu präzisieren.

Bugfixes:
- Verhindern, dass vollständige Server-Refresh-Auswertungen verworfen werden, während Trigger-Zeitstempel persistiert werden.
- Regeln mit ausstehender Trigger-Persistierung von der Erzeugung doppelter Alarm-Trigger-Ereignisse ausschließen.
- Die frühzeitige Rückkehrbedingung des Evaluators klarer machen, indem die Prüfungen auf leere Serverlisten explizit gruppiert werden.

Verbesserungen:
- Zeitstempel ausgelöster Regeln asynchron im Hintergrund persistieren, während ausstehende Regel-IDs nachverfolgt werden, um die Auswertung von der Persistenzlatenz zu entkoppeln.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine alert evaluation to avoid skipping evaluations during trigger persistence and to clarify rule evaluation conditions.

Bug Fixes:
- Prevent full server refresh evaluations from being dropped while trigger timestamps are being persisted.
- Exclude rules with pending trigger persistence from generating duplicate alert trigger events.
- Clarify the evaluator early-return condition by explicitly grouping the empty server list checks.

Enhancements:
- Persist triggered rule timestamps asynchronously in the background while tracking pending rule IDs to decouple evaluation from persistence latency.

</details>

</details>