### PR TITLE
Fix alert history Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -242,6 +242,12 @@ service cloud.firestore {
       allow delete: if isSignedIn() && request.auth.uid == uid;
     }
 
+    // -------- USER ALERT EVENTS --------
+    match /users/{uid}/alert_events/{eventId} {
+      allow read, delete: if isSignedIn() && request.auth.uid == uid;
+      allow create, update: if false;
+    }
+
     // -------- PLAYER SIGHTINGS --------
     match /player_sightings/{sightingId} {
 
@@ -449,7 +455,7 @@ service cloud.firestore {
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.platform in ['android', 'ios']
         && request.resource.data.productId is string
-        && request.resource.data.productId.size() > 0
+        && request.resource.data.size() > 0
         && request.resource.data.purchaseId is string
         && request.resource.data.purchaseId.size() > 0
         && request.resource.data.purchaseToken is string

--- a/firestore.rules
+++ b/firestore.rules
@@ -455,7 +455,7 @@ service cloud.firestore {
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.platform in ['android', 'ios']
         && request.resource.data.productId is string
-        && request.resource.data.size() > 0
+        && request.resource.data.productId.size() > 0
         && request.resource.data.purchaseId is string
         && request.resource.data.purchaseId.size() > 0
         && request.resource.data.purchaseToken is string


### PR DESCRIPTION
Allows signed-in users to read and delete their own alert event history.

This fixes the Alert History loading error caused by missing Firestore rules for users/{uid}/alert_events.

## Summary by Sourcery

Bug Fixes:
- Authentifizierten Nutzern erlauben, ihren eigenen Verlauf von Alarmereignissen zu lesen und zu löschen, um Ladefehler im Alarmverlauf zu beheben.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow authenticated users to read and delete their own alert event history to resolve Alert History loading errors.

</details>