### PR TITLE
Fix FCM token Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -55,6 +55,17 @@ service cloud.firestore {
       return p in ['steam', 'xbox', 'psn', 'unknown'];
     }
 
+    function validFcmPlatform(p) {
+      return p in [
+        'android',
+        'ios',
+        'macos',
+        'windows',
+        'linux',
+        'fuchsia'
+      ];
+    }
+
     function validCreatorLevel(c) {
       return c in ['free', 'premium', 'admin'];
     }
@@ -136,6 +147,21 @@ service cloud.firestore {
         && validPlatform(request.resource.data.platform)
         && validSharingScope(request.resource.data.sharingScope)
         && validOptionalString(request.resource.data.note);
+    }
+
+    function validFcmTokenDocumentShape() {
+      return request.resource.data.keys().hasOnly([
+        'token',
+        'platform',
+        'createdAt',
+        'updatedAt'
+      ]);
+    }
+
+    function validFcmTokenDocumentValues() {
+      return validRequiredNonEmptyString(request.resource.data.token)
+        && validFcmPlatform(request.resource.data.platform)
+        && request.resource.data.updatedAt == request.time;
     }
 
     // -------- USERS --------
@@ -240,6 +266,23 @@ service cloud.firestore {
         && request.resource.data.updatedAt == request.time;
 
       allow delete: if isSignedIn() && request.auth.uid == uid;
+    }
+
+    // -------- USER FCM TOKENS --------
+    match /users/{uid}/fcm_tokens/{tokenId} {
+      allow read, delete: if isSignedIn() && request.auth.uid == uid;
+
+      allow create: if isSignedIn()
+        && request.auth.uid == uid
+        && validFcmTokenDocumentShape()
+        && validFcmTokenDocumentValues()
+        && request.resource.data.createdAt == request.time;
+
+      allow update: if isSignedIn()
+        && request.auth.uid == uid
+        && validFcmTokenDocumentShape()
+        && validFcmTokenDocumentValues()
+        && request.resource.data.createdAt == resource.data.createdAt;
     }
 
     // -------- USER ALERT EVENTS --------


### PR DESCRIPTION
Allows signed-in users to create, update, read, and delete their own FCM token documents under users/{uid}/fcm_tokens.

## Summary by Sourcery

Bug Fixes:
- Firestore-Regeln korrigiert, damit authentifizierte Benutzer nur ihre eigenen FCM-Token-Dokumente erstellen, lesen, aktualisieren und löschen können.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct Firestore rules so authenticated users can create, read, update, and delete only their own FCM token documents.

</details>