### PR TITLE
Fix FCM token create flow

### DIFF
--- a/lib/features/notifications/data/repositories/fcm_token_repository.dart
+++ b/lib/features/notifications/data/repositories/fcm_token_repository.dart
@@ -32,18 +32,16 @@ class FcmTokenRepository {
       'updatedAt': FieldValue.serverTimestamp(),
     };
 
-    try {
+    final snapshot = await docRef.get();
+    if (snapshot.exists) {
       await docRef.update(updateData);
-    } on FirebaseException catch (error) {
-      if (error.code != 'not-found') {
-        rethrow;
-      }
-
-      await docRef.set({
-        ...updateData,
-        'createdAt': FieldValue.serverTimestamp(),
-      });
+      return;
     }
+
+    await docRef.set({
+      ...updateData,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
   }
 
   Future<void> removeToken({


### PR DESCRIPTION
Avoids update-before-create for FCM token documents so Firestore rules can validate first-time token registration correctly.

## Summary by Sourcery

Bug Fixes:
- Verhindern von reinen Update-Schreibvorgängen für nicht vorhandene FCM-Token-Dokumente, indem das Dokument erstellt wird, wenn es noch nicht existiert.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent update-only writes for non-existent FCM token documents by creating the document when it does not yet exist.

</details>