### PR TITLE
Local notification fix

### DIFF
--- a/android/app/src/main/kotlin/com/jchillah/asaservereye/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/jchillah/asaservereye/MainActivity.kt
@@ -1,13 +1,170 @@
 package com.jchillah.asaservereye
 
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import io.flutter.embedding.android.FlutterActivity
-
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        createAlertNotificationChannel()
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            LOCAL_NOTIFICATIONS_CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                METHOD_SHOW_ALERT_NOTIFICATION -> {
+                    val title = call.argument<String>(ARG_TITLE)
+                        ?: DEFAULT_ALERT_TITLE
+                    val body = call.argument<String>(ARG_BODY)
+                        ?: DEFAULT_ALERT_BODY
+                    val serverId = call.argument<String>(ARG_SERVER_ID)
+                    val ruleType = call.argument<String>(ARG_RULE_TYPE)
+                    val alertId = call.argument<String>(ARG_ALERT_ID)
+
+                    if (serverId.isNullOrBlank()) {
+                        result.success(statusResult(STATUS_MISSING_SERVER_ID))
+                        return@setMethodCallHandler
+                    }
+
+                    result.success(
+                        showAlertNotification(
+                            title = title,
+                            body = body,
+                            serverId = serverId,
+                            ruleType = ruleType,
+                            alertId = alertId,
+                        ),
+                    )
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun createAlertNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+
+        val channel = NotificationChannel(
+            ALERT_CHANNEL_ID,
+            ALERT_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = ALERT_CHANNEL_DESCRIPTION
+        }
+
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun showAlertNotification(
+        title: String,
+        body: String,
+        serverId: String,
+        ruleType: String?,
+        alertId: String?,
+    ): Map<String, String> {
+        if (!hasNotificationPermission()) {
+            return statusResult(STATUS_PERMISSION_DENIED)
+        }
+
+        val stableAlertId = alertId?.takeIf { it.isNotBlank() }
+            ?: "${serverId}-${System.currentTimeMillis()}"
+        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+            ?: Intent(this, MainActivity::class.java)
+        launchIntent.putExtra(EXTRA_SERVER_ID, serverId)
+        launchIntent.putExtra(EXTRA_RULE_TYPE, ruleType)
+        launchIntent.putExtra(EXTRA_ALERT_ID, stableAlertId)
+        launchIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+
+        val notificationId = stableAlertId.hashCode() and Int.MAX_VALUE
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            notificationId,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(this, ALERT_CHANNEL_ID)
+            .setSmallIcon(applicationInfo.icon)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        return try {
+            NotificationManagerCompat.from(this).notify(notificationId, notification)
+            statusResult(STATUS_SHOWN)
+        } catch (_: SecurityException) {
+            statusResult(STATUS_PERMISSION_DENIED)
+        }
+    }
+
+    private fun hasNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true
+        }
+
+        return ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun statusResult(status: String): Map<String, String> {
+        return mapOf(RESULT_STATUS to status)
+    }
+
+    companion object {
+        private const val LOCAL_NOTIFICATIONS_CHANNEL =
+            "asa_server_eye/local_notifications"
+        private const val METHOD_SHOW_ALERT_NOTIFICATION =
+            "showAlertNotification"
+
+        private const val ARG_TITLE = "title"
+        private const val ARG_BODY = "body"
+        private const val ARG_SERVER_ID = "serverId"
+        private const val ARG_RULE_TYPE = "ruleType"
+        private const val ARG_ALERT_ID = "alertId"
+
+        private const val RESULT_STATUS = "status"
+        private const val STATUS_SHOWN = "shown"
+        private const val STATUS_PERMISSION_DENIED = "permission_denied"
+        private const val STATUS_MISSING_SERVER_ID = "missing_server_id"
+
+        private const val EXTRA_SERVER_ID = "asa_server_eye.extra.SERVER_ID"
+        private const val EXTRA_RULE_TYPE = "asa_server_eye.extra.RULE_TYPE"
+        private const val EXTRA_ALERT_ID = "asa_server_eye.extra.ALERT_ID"
+
+        private const val ALERT_CHANNEL_ID = "asa_server_eye_alerts"
+        private const val ALERT_CHANNEL_NAME = "ASA Server Eye Alerts"
+        private const val ALERT_CHANNEL_DESCRIPTION =
+            "Server population and activity alerts"
+
+        private const val DEFAULT_ALERT_TITLE = "ASA Server Eye Alert"
+        private const val DEFAULT_ALERT_BODY = "Server activity changed."
     }
 }

--- a/lib/app/presentation/app_shell.dart
+++ b/lib/app/presentation/app_shell.dart
@@ -2,6 +2,7 @@
 import 'dart:async';
 
 import 'package:asa_server_eye/core/extensions/context_l10n.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -67,12 +68,11 @@ class AppShell extends ConsumerWidget {
       );
 
       unawaited(
-        localNotificationService.showAlertNotification(
+        _showLocalAlertNotification(
+          service: localNotificationService,
+          event: next,
+          message: message,
           title: next.rule.ruleType.localizedLabel(context),
-          body: message,
-          serverId: next.rule.serverId,
-          ruleType: next.rule.ruleType.firestoreValue,
-          alertId: _alertId(next),
         ),
       );
     });
@@ -144,6 +144,30 @@ class AppShell extends ConsumerWidget {
           ),
         );
       },
+    );
+  }
+
+  Future<void> _showLocalAlertNotification({
+    required LocalAlertNotificationService service,
+    required AlertTriggerEvent event,
+    required String message,
+    required String title,
+  }) async {
+    final result = await service.showAlertNotification(
+      title: title,
+      body: message,
+      serverId: event.rule.serverId,
+      ruleType: event.rule.ruleType.firestoreValue,
+      alertId: _alertId(event),
+    );
+
+    if (result == LocalAlertNotificationResult.shown) {
+      return;
+    }
+
+    debugPrint(
+      'Local alert notification not shown: $result '
+      'for rule ${event.rule.id} on server ${event.rule.serverId}',
     );
   }
 

--- a/lib/app/presentation/app_shell.dart
+++ b/lib/app/presentation/app_shell.dart
@@ -1,8 +1,11 @@
 // app/presentation/app_shell.dart
+import 'dart:async';
+
 import 'package:asa_server_eye/core/extensions/context_l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../features/alerts/domain/entities/alert_rule_type.dart';
 import '../../features/alerts/domain/entities/alert_trigger_event.dart';
 import '../../features/alerts/presentation/controllers/alert_evaluation_controller.dart';
 import '../../features/alerts/presentation/extensions/alert_rule_type_l10n.dart';
@@ -10,6 +13,7 @@ import '../../features/alerts/presentation/providers/alert_rules_providers.dart'
 import '../../features/alerts/presentation/screens/alerts_overview_screen.dart';
 import '../../features/favorites/presentation/screens/favorites_screen.dart';
 import '../../features/notifications/presentation/controllers/fcm_token_registration_controller.dart';
+import '../../features/notifications/presentation/services/local_alert_notification_service.dart';
 import '../../features/servers/presentation/providers/servers_provider.dart';
 import '../../features/servers/presentation/screens/server_list_screen.dart';
 import '../../features/settings/presentation/screens/settings_screen.dart';
@@ -28,6 +32,9 @@ class AppShell extends ConsumerWidget {
 
     final currentIndex = ref.watch(appShellIndexProvider);
     final accessLevelAsync = ref.watch(sightingsAccessLevelProvider);
+    final localNotificationService = ref.watch(
+      localAlertNotificationServiceProvider,
+    );
 
     ref.listen(serverSyncStateProvider, (previous, next) {
       final syncState = next.valueOrNull;
@@ -53,8 +60,20 @@ class AppShell extends ConsumerWidget {
         return;
       }
 
+      final message = _alertEventMessage(context, next);
+
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_alertEventMessage(context, next))),
+        SnackBar(content: Text(message)),
+      );
+
+      unawaited(
+        localNotificationService.showAlertNotification(
+          title: next.rule.ruleType.localizedLabel(context),
+          body: message,
+          serverId: next.rule.serverId,
+          ruleType: next.rule.ruleType.firestoreValue,
+          alertId: _alertId(next),
+        ),
       );
     });
 
@@ -137,5 +156,9 @@ class AppShell extends ConsumerWidget {
 
     return '${event.rule.ruleType.localizedLabel(context)}: '
         '${event.serverName} • ${event.mapName}$populationChange';
+  }
+
+  String _alertId(AlertTriggerEvent event) {
+    return '${event.rule.id}-${DateTime.now().microsecondsSinceEpoch}';
   }
 }

--- a/lib/features/notifications/presentation/services/local_alert_notification_service.dart
+++ b/lib/features/notifications/presentation/services/local_alert_notification_service.dart
@@ -1,0 +1,90 @@
+// features/notifications/presentation/services/local_alert_notification_service.dart
+import 'dart:developer' as developer;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final localAlertNotificationServiceProvider = Provider<LocalAlertNotificationService>(
+  (ref) => const LocalAlertNotificationService(),
+);
+
+class LocalAlertNotificationService {
+  const LocalAlertNotificationService();
+
+  static const String channelName = 'asa_server_eye/local_notifications';
+
+  static const String _methodShowAlertNotification = 'showAlertNotification';
+
+  static const String _argTitle = 'title';
+  static const String _argBody = 'body';
+  static const String _argServerId = 'serverId';
+  static const String _argRuleType = 'ruleType';
+  static const String _argAlertId = 'alertId';
+
+  static const String _statusKey = 'status';
+  static const String _statusShown = 'shown';
+  static const String _statusPermissionDenied = 'permission_denied';
+  static const String _statusMissingServerId = 'missing_server_id';
+
+  static const MethodChannel _channel = MethodChannel(channelName);
+
+  Future<LocalAlertNotificationResult> showAlertNotification({
+    required String title,
+    required String body,
+    required String serverId,
+    required String ruleType,
+    required String alertId,
+  }) async {
+    if (serverId.trim().isEmpty) {
+      return LocalAlertNotificationResult.missingServerId;
+    }
+
+    try {
+      final result = await _channel.invokeMapMethod<String, String>(
+        _methodShowAlertNotification,
+        {
+          _argTitle: title,
+          _argBody: body,
+          _argServerId: serverId,
+          _argRuleType: ruleType,
+          _argAlertId: alertId,
+        },
+      );
+
+      return LocalAlertNotificationResultX.fromStatus(result?[_statusKey]);
+    } on MissingPluginException {
+      return LocalAlertNotificationResult.unsupportedPlatform;
+    } catch (error, stackTrace) {
+      developer.log(
+        'Failed to show local alert notification.',
+        name: 'LocalAlertNotificationService',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return LocalAlertNotificationResult.failed;
+    }
+  }
+}
+
+enum LocalAlertNotificationResult {
+  shown,
+  permissionDenied,
+  missingServerId,
+  unsupportedPlatform,
+  failed,
+}
+
+extension LocalAlertNotificationResultX on LocalAlertNotificationResult {
+  static LocalAlertNotificationResult fromStatus(String? status) {
+    switch (status) {
+      case LocalAlertNotificationService._statusShown:
+        return LocalAlertNotificationResult.shown;
+      case LocalAlertNotificationService._statusPermissionDenied:
+        return LocalAlertNotificationResult.permissionDenied;
+      case LocalAlertNotificationService._statusMissingServerId:
+        return LocalAlertNotificationResult.missingServerId;
+      default:
+        return LocalAlertNotificationResult.failed;
+    }
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Fügen Sie ein plattformkanalgestütztes lokales Benachrichtigungssystem für Alerts hinzu und verbinden Sie es mit Alert-Ereignissen auf Android und in Flutter.

Neue Features:
- Stellen Sie einen lokalen Flutter-seitigen Alert-Benachrichtigungsdienst bereit, der Alert-Daten über einen Method Channel an die Host-Plattform sendet.
- Zeigen Sie lokale Alert-Benachrichtigungen auf Android an, wenn Alert-Regeln ausgelöst werden, einschließlich der Weiterleitung von Tippaktionen zurück in die App mit Alert-Kontext.

Bugfixes:
- Stellen Sie sicher, dass lokale Android-Alert-Benachrichtigungen nur angezeigt werden, wenn die Benachrichtigungsberechtigung erteilt wurde und eine Server-ID vorhanden ist.

Verbesserungen:
- Erstellen Sie einen dedizierten Android-Benachrichtigungskanal für hochpriorisierte Server-Alert-Benachrichtigungen und standardisieren Sie die Statusberichterstattung zurück an Flutter.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a platform channel–backed local alert notification system and wire it into alert events on Android and Flutter.

New Features:
- Expose a Flutter-side local alert notification service that sends alert data to the host platform via a method channel.
- Display local alert notifications on Android when alert rules trigger, including routing tap actions back into the app with alert context.

Bug Fixes:
- Ensure Android local alert notifications are shown only when notification permission is granted and a server ID is provided.

Enhancements:
- Create a dedicated Android notification channel for high-priority server alert notifications and standardize status reporting back to Flutter.

</details>