### PR TITLE
Hotfix: Profilbild-Uploads mit sicheren Storage-Regeln erlauben

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -44,6 +44,9 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
+  "storage": {
+    "rules": "storage.rules"
+  },
   "functions": [
     {
       "source": "functions",

--- a/storage.rules
+++ b/storage.rules
@@ -9,7 +9,8 @@ service firebase.storage {
 
       allow create, update: if request.auth != null
         && request.auth.uid == uid
-        && request.resource.size < 5 * 1024 * 1024;
+        && request.resource.size < 5 * 1024 * 1024
+        && request.resource.contentType.matches('image/.*');
 
       allow delete: if request.auth != null && request.auth.uid == uid;
     }

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,22 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    // Profile avatars are private account data. Only the authenticated owner
+    // may read, create, replace, or delete the single avatar object.
+    match /users/{uid}/profile.jpg {
+      allow read: if request.auth != null && request.auth.uid == uid;
+
+      allow create, update: if request.auth != null
+        && request.auth.uid == uid
+        && request.resource.size < 5 * 1024 * 1024;
+
+      allow delete: if request.auth != null && request.auth.uid == uid;
+    }
+
+    // Deny every storage path that is not explicitly allowed above.
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Profilbilder werden nach `users/{uid}/profile.jpg` in Firebase Storage hochgeladen. Im Repository fehlten jedoch sowohl eine `storage.rules`-Datei als auch die Storage-Konfiguration in `firebase.json`. Dadurch können Uploads in der veröffentlichten App mit `storage/unauthorized` scheitern; der Profilbildschirm zeigt anschließend nur die allgemeine Meldung „Profil konnte nicht gespeichert werden“.

## Änderungen

- sichere Firebase-Storage-Regeln für Profilbilder ergänzt
- Lesen, Hochladen, Ersetzen und Löschen ausschließlich für den angemeldeten Kontoinhaber erlaubt
- Uploadgröße auf weniger als 5 MB begrenzt
- Upload zusätzlich auf Bild-MIME-Typen (`image/*`) beschränkt
- alle nicht ausdrücklich freigegebenen Storage-Pfade standardmäßig gesperrt
- `storage.rules` in `firebase.json` für reproduzierbare Deployments registriert

## Produktionshinweis

Nach dem Merge müssen die Regeln mit folgendem Befehl in das Firebase-Projekt `asa-server-eye` deployed werden:

```bash
firebase deploy --only storage --project asa-server-eye
```

Für diese serverseitige Korrektur ist kein neues Play-Store-Bundle erforderlich.

## Prüfung

- Diff gegen `main`: ausschließlich `firebase.json` und neue `storage.rules`
- keine App-Abhängigkeiten oder UI-Dateien geändert
- Firestore-Regeln bleiben unverändert
- PR-Workflow führt `flutter analyze`, `flutter test` und einen Release-AAB-Build aus
