### PR TITLE
feat(auth): add password reset flow

### DIFF
--- a/lib/features/auth/data/auth_repository.dart
+++ b/lib/features/auth/data/auth_repository.dart
@@ -21,6 +21,12 @@ class AuthRepository {
     );
   }
 
+  Future<void> sendPasswordResetEmail({required String email}) async {
+    await _firebaseAuth.sendPasswordResetEmail(
+      email: email.trim().toLowerCase(),
+    );
+  }
+
   Future<void> signUp({
     required String username,
     required String email,

--- a/lib/features/auth/presentation/controllers/sign_in_controller.dart
+++ b/lib/features/auth/presentation/controllers/sign_in_controller.dart
@@ -84,4 +84,44 @@ class SignInController {
       return l10n.genericError;
     }
   }
+
+  Future<String> sendPasswordResetEmail({
+    required BuildContext context,
+    required String email,
+  }) async {
+    final l10n = context.l10n;
+    final emailError = AuthFormValidators.validateEmail(context, email);
+    if (emailError != null) {
+      return emailError;
+    }
+
+    try {
+      await _repository.sendPasswordResetEmail(email: email);
+      return l10n.passwordResetEmailSent;
+    } on FirebaseAuthException catch (error, stackTrace) {
+      AppLogger.error(
+        'SignInController',
+        'Password reset failed with FirebaseAuthException.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+
+      return AuthErrorMapper.mapPasswordResetError(
+        code: error.code,
+        invalidEmailFormat: l10n.authInvalidEmailFormat,
+        userDisabled: l10n.authUserDisabled,
+        networkError: l10n.networkError,
+        genericError: l10n.genericError,
+      );
+    } catch (error, stackTrace) {
+      AppLogger.error(
+        'SignInController',
+        'Unexpected password reset error.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+
+      return l10n.genericError;
+    }
+  }
 }

--- a/lib/features/auth/presentation/screens/forgot_password_screen.dart
+++ b/lib/features/auth/presentation/screens/forgot_password_screen.dart
@@ -1,0 +1,102 @@
+import 'package:asa_server_eye/app/presentation/widgets/app_action_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/extensions/context_l10n.dart';
+import '../controllers/sign_in_controller.dart';
+import '../utils/auth_feedback.dart';
+import '../widgets/app_gradient_background.dart';
+import '../widgets/auth_email_field.dart';
+import '../widgets/auth_screen_header.dart';
+
+class ForgotPasswordScreen extends ConsumerStatefulWidget {
+  const ForgotPasswordScreen({super.key, this.initialEmail = ''});
+
+  final String initialEmail;
+
+  @override
+  ConsumerState<ForgotPasswordScreen> createState() =>
+      _ForgotPasswordScreenState();
+}
+
+class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
+  late final TextEditingController _emailController;
+  bool _isSubmitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _emailController = TextEditingController(text: widget.initialEmail.trim());
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    FocusManager.instance.primaryFocus?.unfocus();
+    setState(() => _isSubmitting = true);
+
+    final message = await ref
+        .read(signInControllerProvider)
+        .sendPasswordResetEmail(context: context, email: _emailController.text);
+
+    if (!mounted) return;
+    setState(() => _isSubmitting = false);
+    AuthFeedback.showMessage(context, message);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(context.l10n.resetPassword)),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: AppGradientBackground(
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                AuthScreenHeader(
+                  imagePath: 'assets/images/app_logo.png',
+                  title: context.l10n.forgotPassword,
+                  subtitle: context.l10n.resetPasswordInstructions,
+                ),
+                const SizedBox(height: 24),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      children: [
+                        AuthEmailField(
+                          controller: _emailController,
+                          labelText: context.l10n.email,
+                          hintText: 'name@email.com',
+                        ),
+                        const SizedBox(height: 24),
+                        AppActionButton(
+                          label: context.l10n.sendResetLink,
+                          isLoading: _isSubmitting,
+                          onPressed: _submit,
+                        ),
+                        const SizedBox(height: 8),
+                        AppActionButton(
+                          label: context.l10n.signIn,
+                          isLoading: _isSubmitting,
+                          variant: AppActionButtonVariant.secondary,
+                          onPressed: () async => Navigator.of(context).pop(),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/sign_in_screen.dart
+++ b/lib/features/auth/presentation/screens/sign_in_screen.dart
@@ -52,7 +52,20 @@ class SignInScreen extends ConsumerWidget {
                           labelText: context.l10n.password,
                           autofillHints: const [AutofillHints.password],
                         ),
-                        const SizedBox(height: 20),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: TextButton(
+                            onPressed: formController.isSubmitting
+                                ? null
+                                : () => AuthNavigation.openForgotPassword(
+                                    context,
+                                    initialEmail:
+                                        formController.emailController.text,
+                                  ),
+                            child: Text(context.l10n.forgotPassword),
+                          ),
+                        ),
+                        const SizedBox(height: 8),
                         AppActionButton(
                           label: context.l10n.signIn,
                           isLoading: formController.isSubmitting,

--- a/lib/features/auth/presentation/utils/auth_error_mapper.dart
+++ b/lib/features/auth/presentation/utils/auth_error_mapper.dart
@@ -45,4 +45,23 @@ abstract final class AuthErrorMapper {
         return genericError;
     }
   }
+
+  static String mapPasswordResetError({
+    required String code,
+    required String invalidEmailFormat,
+    required String userDisabled,
+    required String networkError,
+    required String genericError,
+  }) {
+    switch (code) {
+      case 'invalid-email':
+        return invalidEmailFormat;
+      case 'user-disabled':
+        return userDisabled;
+      case 'network-request-failed':
+        return networkError;
+      default:
+        return genericError;
+    }
+  }
 }

--- a/lib/features/auth/presentation/utils/auth_form_validators.dart
+++ b/lib/features/auth/presentation/utils/auth_form_validators.dart
@@ -31,7 +31,7 @@ abstract final class AuthFormValidators {
     final trimmedEmail = email.trim();
 
     if (trimmedEmail.isEmpty) {
-      return context.l10n.authMissingEmailOrPassword;
+      return context.l10n.authMissingEmail;
     }
 
     final emailRegex = RegExp(r'^[^@]+@[^@]+\.[^@]+$');

--- a/lib/features/auth/presentation/utils/auth_navigation.dart
+++ b/lib/features/auth/presentation/utils/auth_navigation.dart
@@ -1,9 +1,21 @@
 // features/auth/presentation/utils/auth_navigation.dart
 import 'package:flutter/material.dart';
 
+import '../screens/forgot_password_screen.dart';
 import '../screens/sign_up_screen.dart';
 
 abstract final class AuthNavigation {
+  static Future<void> openForgotPassword(
+    BuildContext context, {
+    String initialEmail = '',
+  }) {
+    return Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ForgotPasswordScreen(initialEmail: initialEmail),
+      ),
+    );
+  }
+
   static Future<void> openSignUp(BuildContext context) {
     return Navigator.of(
       context,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1030,5 +1030,17 @@
   "alertTypeServerOffline": "Server offline",
   "@alertTypeServerOffline": {
     "description": "Bezeichnung für Alert-Typ"
-  }
+  },
+  "forgotPassword": "Passwort vergessen?",
+  "@forgotPassword": {
+    "description": "Schaltfläche zum Anfordern einer E-Mail zum Zurücksetzen des Passworts"
+  },
+  "passwordResetEmailSent": "Falls ein Konto für diese E-Mail existiert, wurde ein Link zum Zurücksetzen gesendet.",
+  "@passwordResetEmailSent": {
+    "description": "Bestätigung nach dem Anfordern einer Passwort-Reset-E-Mail"
+  },
+  "authMissingEmail": "Bitte gib deine E-Mail-Adresse ein.",
+  "resetPassword": "Passwort zurücksetzen",
+  "resetPasswordInstructions": "Gib deine E-Mail-Adresse ein. Wir senden dir einen Link zum Zurücksetzen deines Passworts.",
+  "sendResetLink": "Reset-Link senden"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1030,5 +1030,17 @@
   "alertTypeServerOffline": "Server offline",
   "@alertTypeServerOffline": {
     "description": "Label for alert type indicating that the server is offline"
-  }
-} 
+  },
+  "forgotPassword": "Forgot password?",
+  "@forgotPassword": {
+    "description": "Button on the sign-in screen that sends a password reset email"
+  },
+  "passwordResetEmailSent": "If an account exists for this email, a password reset link has been sent.",
+  "@passwordResetEmailSent": {
+    "description": "Confirmation after requesting a password reset email"
+  },
+  "authMissingEmail": "Please enter your email address.",
+  "resetPassword": "Reset password",
+  "resetPasswordInstructions": "Enter your email address and we’ll send you a link to reset your password.",
+  "sendResetLink": "Send reset link"
+}

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1030,5 +1030,17 @@
     "alertTypeServerOffline": "Servidor fuera de línea",
     "@alertTypeServerOffline": {
         "description": "Etiqueta del tipo de alerta"
-    }
+    },
+    "forgotPassword": "¿Olvidaste tu contraseña?",
+    "@forgotPassword": {
+        "description": "Botón para solicitar un correo de restablecimiento de contraseña"
+    },
+    "passwordResetEmailSent": "Si existe una cuenta para este correo, se ha enviado un enlace para restablecer la contraseña.",
+    "@passwordResetEmailSent": {
+        "description": "Confirmación tras solicitar el restablecimiento de contraseña"
+    },
+    "authMissingEmail": "Introduce tu correo electrónico.",
+    "resetPassword": "Restablecer contraseña",
+    "resetPasswordInstructions": "Introduce tu correo y te enviaremos un enlace para restablecer tu contraseña.",
+    "sendResetLink": "Enviar enlace"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1030,5 +1030,17 @@
     "alertTypeServerOffline": "Serveur hors ligne",
     "@alertTypeServerOffline": {
         "description": "Libellé du type d’alerte"
-    }
+    },
+    "forgotPassword": "Mot de passe oublié ?",
+    "@forgotPassword": {
+        "description": "Bouton pour demander un e-mail de réinitialisation du mot de passe"
+    },
+    "passwordResetEmailSent": "Si un compte existe pour cet e-mail, un lien de réinitialisation a été envoyé.",
+    "@passwordResetEmailSent": {
+        "description": "Confirmation après une demande de réinitialisation du mot de passe"
+    },
+    "authMissingEmail": "Saisissez votre adresse e-mail.",
+    "resetPassword": "Réinitialiser le mot de passe",
+    "resetPasswordInstructions": "Saisissez votre adresse e-mail et nous vous enverrons un lien de réinitialisation.",
+    "sendResetLink": "Envoyer le lien"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -65,7 +65,8 @@ import 'app_localizations_zh.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -73,7 +74,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -85,12 +87,13 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -98,7 +101,7 @@ abstract class AppLocalizations {
     Locale('en'),
     Locale('es'),
     Locale('fr'),
-    Locale('zh')
+    Locale('zh'),
   ];
 
   /// The application name
@@ -1552,9 +1555,46 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Server offline'**
   String get alertTypeServerOffline;
+
+  /// Button on the sign-in screen that sends a password reset email
+  ///
+  /// In en, this message translates to:
+  /// **'Forgot password?'**
+  String get forgotPassword;
+
+  /// Confirmation after requesting a password reset email
+  ///
+  /// In en, this message translates to:
+  /// **'If an account exists for this email, a password reset link has been sent.'**
+  String get passwordResetEmailSent;
+
+  /// No description provided for @authMissingEmail.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your email address.'**
+  String get authMissingEmail;
+
+  /// No description provided for @resetPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset password'**
+  String get resetPassword;
+
+  /// No description provided for @resetPasswordInstructions.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your email address and we’ll send you a link to reset your password.'**
+  String get resetPasswordInstructions;
+
+  /// No description provided for @sendResetLink.
+  ///
+  /// In en, this message translates to:
+  /// **'Send reset link'**
+  String get sendResetLink;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -1563,28 +1603,32 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['de', 'en', 'es', 'fr', 'zh'].contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      <String>['de', 'en', 'es', 'fr', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
-
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'de': return AppLocalizationsDe();
-    case 'en': return AppLocalizationsEn();
-    case 'es': return AppLocalizationsEs();
-    case 'fr': return AppLocalizationsFr();
-    case 'zh': return AppLocalizationsZh();
+    case 'de':
+      return AppLocalizationsDe();
+    case 'en':
+      return AppLocalizationsEn();
+    case 'es':
+      return AppLocalizationsEs();
+    case 'fr':
+      return AppLocalizationsFr();
+    case 'zh':
+      return AppLocalizationsZh();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
+    'that was used.',
   );
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -150,7 +150,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get french => 'Französisch';
 
   @override
-  String get genericError => 'Ein Fehler ist aufgetreten. Bitte versuche es erneut.';
+  String get genericError =>
+      'Ein Fehler ist aufgetreten. Bitte versuche es erneut.';
 
   @override
   String get loading => 'Lädt';
@@ -177,7 +178,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get welcomeBack => 'Willkommen zurück';
 
   @override
-  String get signInToContinue => 'Melde dich an, um mit deinen gespeicherten Daten fortzufahren.';
+  String get signInToContinue =>
+      'Melde dich an, um mit deinen gespeicherten Daten fortzufahren.';
 
   @override
   String get createAccount => 'Konto erstellen';
@@ -186,7 +188,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get createYourAccount => 'Erstelle dein Konto';
 
   @override
-  String get signUpToSaveFavorites => 'Registriere dich, um deine Favoriten geräteübergreifend zu speichern.';
+  String get signUpToSaveFavorites =>
+      'Registriere dich, um deine Favoriten geräteübergreifend zu speichern.';
 
   @override
   String get account => 'Konto';
@@ -201,7 +204,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authMissingEmailOrPassword => 'Bitte gib E-Mail und Passwort ein.';
 
   @override
-  String get authInvalidEmailFormat => 'Bitte gib eine gültige E-Mail-Adresse ein.';
+  String get authInvalidEmailFormat =>
+      'Bitte gib eine gültige E-Mail-Adresse ein.';
 
   @override
   String get authUserDisabled => 'Dieses Konto wurde deaktiviert.';
@@ -213,34 +217,41 @@ class AppLocalizationsDe extends AppLocalizations {
   String get networkError => 'Netzwerkfehler. Bitte versuche es erneut.';
 
   @override
-  String get authWeakPassword => 'Das Passwort muss mindestens 6 Zeichen lang sein.';
+  String get authWeakPassword =>
+      'Das Passwort muss mindestens 6 Zeichen lang sein.';
 
   @override
   String get authEmailAlreadyInUse => 'Diese E-Mail wird bereits verwendet.';
 
   @override
-  String get aboutBody => 'ASA Server Eye ist eine Companion-App für ARK: Survival Ascended. Die App zeigt Serverinformationen, unterstützt Favoriten und bildet die Grundlage für spätere Funktionen wie Watchlist, Benachrichtigungen und Premium-Features.\n\nVerantwortlich für Entwicklung und Betrieb:\nMichael Winkler\nE-Mail: asa.server.eye@gmail.com';
+  String get aboutBody =>
+      'ASA Server Eye ist eine Companion-App für ARK: Survival Ascended. Die App zeigt Serverinformationen, unterstützt Favoriten und bildet die Grundlage für spätere Funktionen wie Watchlist, Benachrichtigungen und Premium-Features.\n\nVerantwortlich für Entwicklung und Betrieb:\nMichael Winkler\nE-Mail: asa.server.eye@gmail.com';
 
   @override
-  String get privacyBody => 'Datenschutzerklärung\n\nVerantwortlich für die Datenverarbeitung:\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nE-Mail: asa.server.eye@gmail.com\n\nDiese App verwendet Firebase Authentication zur Anmeldung von Nutzerkonten, Cloud Firestore zum Speichern persönlicher Favoriten sowie Google AdMob zur Auslieferung von Werbung.\n\nDabei können je nach Nutzung technische Daten verarbeitet werden, insbesondere Kontodaten, Geräteinformationen, App-Interaktionen, Kennungen, Diagnoseinformationen und werbebezogene Daten. Favoriten werden nutzerbezogen gespeichert, damit sie nach einem erneuten Start der App und auf mehreren Geräten verfügbar bleiben.\n\nDie Verarbeitung erfolgt zur Bereitstellung der App-Funktionen, zur Authentifizierung, zur Speicherung nutzerbezogener Einstellungen und zur Finanzierung der App über Werbung.\n\nEs kann nicht ausgeschlossen werden, dass eingesetzte Drittanbieter Daten außerhalb der Europäischen Union verarbeiten. Maßgeblich sind insoweit auch die Datenschutzinformationen der jeweils eingebundenen Dienste, insbesondere von Google Firebase und Google AdMob.\n\nBei Fragen zum Datenschutz oder zur Löschung deiner Daten kontaktiere bitte:\nasa.server.eye@gmail.com\n\nHinweis: Vor einem endgültigen öffentlichen Release sollte diese Datenschutzerklärung noch einmal rechtlich geprüft und um vollständige Angaben zu Rechtsgrundlagen, Speicherdauer, Betroffenenrechten und allen eingebundenen Diensten ergänzt werden.';
+  String get privacyBody =>
+      'Datenschutzerklärung\n\nVerantwortlich für die Datenverarbeitung:\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nE-Mail: asa.server.eye@gmail.com\n\nDiese App verwendet Firebase Authentication zur Anmeldung von Nutzerkonten, Cloud Firestore zum Speichern persönlicher Favoriten sowie Google AdMob zur Auslieferung von Werbung.\n\nDabei können je nach Nutzung technische Daten verarbeitet werden, insbesondere Kontodaten, Geräteinformationen, App-Interaktionen, Kennungen, Diagnoseinformationen und werbebezogene Daten. Favoriten werden nutzerbezogen gespeichert, damit sie nach einem erneuten Start der App und auf mehreren Geräten verfügbar bleiben.\n\nDie Verarbeitung erfolgt zur Bereitstellung der App-Funktionen, zur Authentifizierung, zur Speicherung nutzerbezogener Einstellungen und zur Finanzierung der App über Werbung.\n\nEs kann nicht ausgeschlossen werden, dass eingesetzte Drittanbieter Daten außerhalb der Europäischen Union verarbeiten. Maßgeblich sind insoweit auch die Datenschutzinformationen der jeweils eingebundenen Dienste, insbesondere von Google Firebase und Google AdMob.\n\nBei Fragen zum Datenschutz oder zur Löschung deiner Daten kontaktiere bitte:\nasa.server.eye@gmail.com\n\nHinweis: Vor einem endgültigen öffentlichen Release sollte diese Datenschutzerklärung noch einmal rechtlich geprüft und um vollständige Angaben zu Rechtsgrundlagen, Speicherdauer, Betroffenenrechten und allen eingebundenen Diensten ergänzt werden.';
 
   @override
-  String get imprintBody => 'Impressum\n\nAngaben gemäß § 5 TMG / § 18 MStV\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nDeutschland\n\nE-Mail:\nasa.server.eye@gmail.com\n\nVerantwortlich für den Inhalt:\nMichael Winkler';
+  String get imprintBody =>
+      'Impressum\n\nAngaben gemäß § 5 TMG / § 18 MStV\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nDeutschland\n\nE-Mail:\nasa.server.eye@gmail.com\n\nVerantwortlich für den Inhalt:\nMichael Winkler';
 
   @override
-  String get supportBody => 'Support\n\nBei Fragen, Problemen oder Feedback zur App kontaktiere bitte:\n\nMichael Winkler\nE-Mail: asa.server.eye@gmail.com\n\nBitte beschreibe dein Problem möglichst genau und nenne dabei möglichst auch dein Gerät sowie die verwendete App-Version.';
+  String get supportBody =>
+      'Support\n\nBei Fragen, Problemen oder Feedback zur App kontaktiere bitte:\n\nMichael Winkler\nE-Mail: asa.server.eye@gmail.com\n\nBitte beschreibe dein Problem möglichst genau und nenne dabei möglichst auch dein Gerät sowie die verwendete App-Version.';
 
   @override
   String get contactSupport => 'Support kontaktieren';
 
   @override
-  String get emailAppCouldNotBeOpened => 'E-Mail-App konnte nicht geöffnet werden.';
+  String get emailAppCouldNotBeOpened =>
+      'E-Mail-App konnte nicht geöffnet werden.';
 
   @override
   String get supportEmailSubject => 'ASA Server Eye Support';
 
   @override
-  String get supportEmailBodyTemplate => 'Hallo Michael,\n\nich habe folgendes Problem:\n\n\n---\nApp-Version:\nGerät:\n';
+  String get supportEmailBodyTemplate =>
+      'Hallo Michael,\n\nich habe folgendes Problem:\n\n\n---\nApp-Version:\nGerät:\n';
 
   @override
   String get fullPrivacyPolicy => 'Vollständige Datenschutzerklärung';
@@ -273,7 +284,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileDeleteError => 'Konto konnte nicht gelöscht werden.';
 
   @override
-  String get deleteAccountHint => 'Beim Löschen wird das Profil entfernt. Bereits erstellte Sightings bleiben erhalten.';
+  String get deleteAccountHint =>
+      'Beim Löschen wird das Profil entfernt. Bereits erstellte Sightings bleiben erhalten.';
 
   @override
   String savedFavoritesCount(int count) {
@@ -284,13 +296,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get usernameEmpty => 'Bitte gib einen Benutzernamen ein.';
 
   @override
-  String get usernameTooShort => 'Der Benutzername muss mindestens 3 Zeichen lang sein.';
+  String get usernameTooShort =>
+      'Der Benutzername muss mindestens 3 Zeichen lang sein.';
 
   @override
-  String get usernameTooLong => 'Der Benutzername darf maximal 20 Zeichen lang sein.';
+  String get usernameTooLong =>
+      'Der Benutzername darf maximal 20 Zeichen lang sein.';
 
   @override
-  String get usernameInvalidCharacters => 'Der Benutzername darf nur Buchstaben, Zahlen, Punkt, Unterstrich und Bindestrich enthalten.';
+  String get usernameInvalidCharacters =>
+      'Der Benutzername darf nur Buchstaben, Zahlen, Punkt, Unterstrich und Bindestrich enthalten.';
 
   @override
   String get deleteAccountDialogTitle => 'Konto löschen';
@@ -373,19 +388,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get sightingSaveError => 'Sichtung konnte nicht gespeichert werden.';
 
   @override
-  String get sightingUpdateError => 'Sichtung konnte nicht aktualisiert werden.';
+  String get sightingUpdateError =>
+      'Sichtung konnte nicht aktualisiert werden.';
 
   @override
   String get sightingHideError => 'Sichtung konnte nicht ausgeblendet werden.';
 
   @override
-  String get sightingRequiresLogin => 'Du musst eingeloggt sein, um eine Sichtung zu melden.';
+  String get sightingRequiresLogin =>
+      'Du musst eingeloggt sein, um eine Sichtung zu melden.';
 
   @override
-  String get sightingDeleteNotAllowed => 'Du darfst diese Sichtung nicht löschen.';
+  String get sightingDeleteNotAllowed =>
+      'Du darfst diese Sichtung nicht löschen.';
 
   @override
-  String get sightingEditNotAllowed => 'Du darfst diese Sichtung nicht bearbeiten.';
+  String get sightingEditNotAllowed =>
+      'Du darfst diese Sichtung nicht bearbeiten.';
 
   @override
   String get sightingInGameNameRequired => 'Bitte Spielernamen eingeben.';
@@ -400,7 +419,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get sightingReasonRequired => 'Bitte Grund angeben.';
 
   @override
-  String get sightingDeleteHint => 'Die Sichtung wird nicht endgültig gelöscht. Sie wird nur für normale Nutzer ausgeblendet und bleibt für Admins nachvollziehbar.';
+  String get sightingDeleteHint =>
+      'Die Sichtung wird nicht endgültig gelöscht. Sie wird nur für normale Nutzer ausgeblendet und bleibt für Admins nachvollziehbar.';
 
   @override
   String get reason => 'Grund';
@@ -421,7 +441,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noSightingHistory => 'Noch kein Verlauf vorhanden.';
 
   @override
-  String get accessLevelLoadError => 'Zugriffslevel konnte nicht geladen werden.';
+  String get accessLevelLoadError =>
+      'Zugriffslevel konnte nicht geladen werden.';
 
   @override
   String get edit => 'Bearbeiten';
@@ -445,7 +466,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get platformUnknown => 'Unbekannt';
 
   @override
-  String get sightingUserProfileLoadError => 'Benutzerprofil konnte nicht geladen werden.';
+  String get sightingUserProfileLoadError =>
+      'Benutzerprofil konnte nicht geladen werden.';
 
   @override
   String get playerSightings => 'Spielersichtungen';
@@ -520,25 +542,29 @@ class AppLocalizationsDe extends AppLocalizations {
   String get accountCreated => 'Konto erfolgreich erstellt';
 
   @override
-  String get accountCreationFailed => 'Konto konnte nicht erstellt werden. Bitte versuche es erneut.';
+  String get accountCreationFailed =>
+      'Konto konnte nicht erstellt werden. Bitte versuche es erneut.';
 
   @override
   String get accountDeleted => 'Konto erfolgreich gelöscht';
 
   @override
-  String get accountDeletionFailed => 'Konto konnte nicht gelöscht werden. Bitte versuche es erneut.';
+  String get accountDeletionFailed =>
+      'Konto konnte nicht gelöscht werden. Bitte versuche es erneut.';
 
   @override
   String get deletePermanently => 'Endgültig löschen';
 
   @override
-  String get deletePermanentlyConfirmation => 'Diese Sichtung und ihre Historie werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get deletePermanentlyConfirmation =>
+      'Diese Sichtung und ihre Historie werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get sightingDeletedPermanently => 'Sichtung dauerhaft gelöscht';
 
   @override
-  String get premiumRequiredForMoreFavorites => 'Für mehr als einen Favoriten benötigst du Premium.';
+  String get premiumRequiredForMoreFavorites =>
+      'Für mehr als einen Favoriten benötigst du Premium.';
 
   @override
   String get serversNavLabel => 'Server';
@@ -562,25 +588,29 @@ class AppLocalizationsDe extends AppLocalizations {
   String get premiumHeadline => 'Schalte Premium frei';
 
   @override
-  String get premiumDescription => 'Mit Premium erhältst du Zugriff auf Spielersichtungen, mehr Favoriten und zukünftige Premium-Funktionen.';
+  String get premiumDescription =>
+      'Mit Premium erhältst du Zugriff auf Spielersichtungen, mehr Favoriten und zukünftige Premium-Funktionen.';
 
   @override
   String get premiumBenefitSightingsTitle => 'Spielersichtungen';
 
   @override
-  String get premiumBenefitSightingsDescription => 'Greife direkt über die Navigation auf Sichtungen zu und nutze Premium-Zugriff im gesamten Bereich.';
+  String get premiumBenefitSightingsDescription =>
+      'Greife direkt über die Navigation auf Sichtungen zu und nutze Premium-Zugriff im gesamten Bereich.';
 
   @override
   String get premiumBenefitFavoritesTitle => 'Mehr Favoriten';
 
   @override
-  String get premiumBenefitFavoritesDescription => 'Speichere deutlich mehr Server in deinen Favoriten.';
+  String get premiumBenefitFavoritesDescription =>
+      'Speichere deutlich mehr Server in deinen Favoriten.';
 
   @override
   String get premiumBenefitAlertsTitle => 'Zukünftige Extras';
 
   @override
-  String get premiumBenefitAlertsDescription => 'Bereite dich auf kommende Premium-Funktionen wie erweiterte Beobachtung und Alarme vor.';
+  String get premiumBenefitAlertsDescription =>
+      'Bereite dich auf kommende Premium-Funktionen wie erweiterte Beobachtung und Alarme vor.';
 
   @override
   String get premiumMonthlyPlan => 'Monatlich';
@@ -592,7 +622,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get premiumYearlyPlan => 'Jährlich';
 
   @override
-  String get premiumYearlyPlanDescription => 'Bester Wert für langfristige Nutzung';
+  String get premiumYearlyPlanDescription =>
+      'Bester Wert für langfristige Nutzung';
 
   @override
   String get premiumStartMonthly => 'Monatlich starten';
@@ -604,19 +635,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get restorePurchases => 'Käufe wiederherstellen';
 
   @override
-  String get premiumPurchaseComingSoon => 'Der Kauf-Flow wird als Nächstes angebunden.';
+  String get premiumPurchaseComingSoon =>
+      'Der Kauf-Flow wird als Nächstes angebunden.';
 
   @override
   String get premiumUpgradeTitle => 'Upgrade auf Premium';
 
   @override
-  String get premiumUpgradeDescription => 'Schalte den Sightings-Tab und weitere Premium-Vorteile frei.';
+  String get premiumUpgradeDescription =>
+      'Schalte den Sightings-Tab und weitere Premium-Vorteile frei.';
 
   @override
   String get premiumActiveTitle => 'Premium aktiv';
 
   @override
-  String get premiumActiveDescription => 'Dein Konto hat bereits Zugriff auf Premium-Funktionen.';
+  String get premiumActiveDescription =>
+      'Dein Konto hat bereits Zugriff auf Premium-Funktionen.';
 
   @override
   String get unlockPremium => 'Premium freischalten';
@@ -625,28 +659,35 @@ class AppLocalizationsDe extends AppLocalizations {
   String get managePremium => 'Premium verwalten';
 
   @override
-  String get premiumStoreUnavailable => 'Der Store ist aktuell nicht verfügbar.';
+  String get premiumStoreUnavailable =>
+      'Der Store ist aktuell nicht verfügbar.';
 
   @override
-  String get premiumProductsUnavailable => 'Aktuell konnten keine Premium-Produkte geladen werden.';
+  String get premiumProductsUnavailable =>
+      'Aktuell konnten keine Premium-Produkte geladen werden.';
 
   @override
-  String get premiumPurchaseError => 'Beim Kauf ist ein Fehler aufgetreten. Bitte versuche es erneut.';
+  String get premiumPurchaseError =>
+      'Beim Kauf ist ein Fehler aufgetreten. Bitte versuche es erneut.';
 
   @override
   String get premiumRestoreSuccess => 'Käufe erfolgreich wiederhergestellt.';
 
   @override
-  String get premiumRestoreError => 'Beim Wiederherstellen der Käufe ist ein Fehler aufgetreten. Bitte versuche es erneut.';
+  String get premiumRestoreError =>
+      'Beim Wiederherstellen der Käufe ist ein Fehler aufgetreten. Bitte versuche es erneut.';
 
   @override
-  String get premiumPurchasePending => 'Dein Kauf wird verarbeitet. Premium wird nach erfolgreicher Verifikation freigeschaltet.';
+  String get premiumPurchasePending =>
+      'Dein Kauf wird verarbeitet. Premium wird nach erfolgreicher Verifikation freigeschaltet.';
 
   @override
-  String get premiumExpiredDescription => 'Dein Premium-Zugang ist abgelaufen. Du kannst jederzeit erneut Premium freischalten.';
+  String get premiumExpiredDescription =>
+      'Dein Premium-Zugang ist abgelaufen. Du kannst jederzeit erneut Premium freischalten.';
 
   @override
-  String get premiumVerificationQueued => 'Dein Kauf wurde übermittelt und wird jetzt verifiziert.';
+  String get premiumVerificationQueued =>
+      'Dein Kauf wurde übermittelt und wird jetzt verifiziert.';
 
   @override
   String get serverSyncSourceLive => 'Quelle: Live-Daten';
@@ -655,7 +696,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get serverSyncSourceCache => 'Quelle: Cache';
 
   @override
-  String get serverSyncCacheBanner => 'Es werden zwischengespeicherte Serverdaten angezeigt';
+  String get serverSyncCacheBanner =>
+      'Es werden zwischengespeicherte Serverdaten angezeigt';
 
   @override
   String get serverSyncCacheStale => 'Cache-Daten könnten veraltet sein';
@@ -672,7 +714,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get serverSyncLoading => 'Synchronisationsstatus wird geladen …';
 
   @override
-  String get serverSyncUnavailable => 'Synchronisationsstatus derzeit nicht verfügbar';
+  String get serverSyncUnavailable =>
+      'Synchronisationsstatus derzeit nicht verfügbar';
 
   @override
   String get alertSettingsTitle => 'Alert-Regeln (Benachrichtigungen)';
@@ -690,13 +733,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get editAlertRule => 'Alert-Regel bearbeiten';
 
   @override
-  String get noAlertRulesYet => 'Für diesen Server gibt es noch keine Alert-Regeln.';
+  String get noAlertRulesYet =>
+      'Für diesen Server gibt es noch keine Alert-Regeln.';
 
   @override
-  String get alertRulesLoadError => 'Alert-Regeln konnten nicht geladen werden.';
+  String get alertRulesLoadError =>
+      'Alert-Regeln konnten nicht geladen werden.';
 
   @override
-  String get alertRulesRequiresLogin => 'Du musst angemeldet sein, um Alert-Regeln zu verwalten.';
+  String get alertRulesRequiresLogin =>
+      'Du musst angemeldet sein, um Alert-Regeln zu verwalten.';
 
   @override
   String get alertRuleType => 'Alert-Typ';
@@ -708,7 +754,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get alertRuleThresholdHint => 'Spieleranzahl eingeben';
 
   @override
-  String get alertRuleThresholdRequired => 'Bitte einen Schwellenwert eingeben.';
+  String get alertRuleThresholdRequired =>
+      'Bitte einen Schwellenwert eingeben.';
 
   @override
   String get alertRuleThresholdInvalid => 'Bitte eine gültige Zahl eingeben.';
@@ -726,7 +773,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteAlertRule => 'Alert-Regel löschen';
 
   @override
-  String get deleteAlertRuleQuestion => 'Möchtest du diese Alert-Regel löschen?';
+  String get deleteAlertRuleQuestion =>
+      'Möchtest du diese Alert-Regel löschen?';
 
   @override
   String get alertRuleSaved => 'Alert-Regel gespeichert.';
@@ -738,7 +786,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get alertRuleDeleted => 'Alert-Regel gelöscht.';
 
   @override
-  String get alertRuleMutationError => 'Alert-Regel konnte nicht gespeichert werden. Bitte versuche es erneut.';
+  String get alertRuleMutationError =>
+      'Alert-Regel konnte nicht gespeichert werden. Bitte versuche es erneut.';
 
   @override
   String get alertTypePopulationIncreased => 'Population gestiegen';
@@ -757,4 +806,24 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get alertTypeServerOffline => 'Server offline';
+
+  @override
+  String get forgotPassword => 'Passwort vergessen?';
+
+  @override
+  String get passwordResetEmailSent =>
+      'Falls ein Konto für diese E-Mail existiert, wurde ein Link zum Zurücksetzen gesendet.';
+
+  @override
+  String get authMissingEmail => 'Bitte gib deine E-Mail-Adresse ein.';
+
+  @override
+  String get resetPassword => 'Passwort zurücksetzen';
+
+  @override
+  String get resetPasswordInstructions =>
+      'Gib deine E-Mail-Adresse ein. Wir senden dir einen Link zum Zurücksetzen deines Passworts.';
+
+  @override
+  String get sendResetLink => 'Reset-Link senden';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -186,7 +186,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get createYourAccount => 'Create your account';
 
   @override
-  String get signUpToSaveFavorites => 'Sign up to save your favorites across devices.';
+  String get signUpToSaveFavorites =>
+      'Sign up to save your favorites across devices.';
 
   @override
   String get account => 'Account';
@@ -198,7 +199,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get signOutDescription => 'Log out of your current account';
 
   @override
-  String get authMissingEmailOrPassword => 'Please enter your email and password.';
+  String get authMissingEmailOrPassword =>
+      'Please enter your email and password.';
 
   @override
   String get authInvalidEmailFormat => 'Please enter a valid email address.';
@@ -219,16 +221,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authEmailAlreadyInUse => 'This email is already in use.';
 
   @override
-  String get aboutBody => 'ASA Server Eye is a companion app for ARK: Survival Ascended. The app shows server information, supports favorites, and provides the foundation for future features such as watchlists, notifications, and premium features.\n\nDeveloped and operated by:\nMichael Winkler\nEmail: asa.server.eye@gmail.com';
+  String get aboutBody =>
+      'ASA Server Eye is a companion app for ARK: Survival Ascended. The app shows server information, supports favorites, and provides the foundation for future features such as watchlists, notifications, and premium features.\n\nDeveloped and operated by:\nMichael Winkler\nEmail: asa.server.eye@gmail.com';
 
   @override
-  String get privacyBody => 'Privacy Policy\n\nController responsible for data processing:\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nGermany\nEmail: asa.server.eye@gmail.com\n\nThis app uses Firebase Authentication for account sign-in, Cloud Firestore to store personal favorites, and Google AdMob to serve ads.\n\nDepending on how the app is used, technical data may be processed, including account data, device information, app interactions, identifiers, diagnostics, and advertising-related data. Favorites are stored per user so they remain available after restarting the app and across multiple devices.\n\nProcessing is carried out to provide app functionality, authenticate users, store user-related settings, and finance the app through advertising.\n\nIt cannot be ruled out that integrated third-party services process data outside the European Union. In this respect, the privacy information of the respective services applies, especially Google Firebase and Google AdMob.\n\nFor privacy-related questions or deletion requests, please contact:\nasa.server.eye@gmail.com\n\nNote: Before a final public release, this privacy policy should be reviewed and expanded with full details on legal bases, retention periods, user rights, and all integrated services.';
+  String get privacyBody =>
+      'Privacy Policy\n\nController responsible for data processing:\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nGermany\nEmail: asa.server.eye@gmail.com\n\nThis app uses Firebase Authentication for account sign-in, Cloud Firestore to store personal favorites, and Google AdMob to serve ads.\n\nDepending on how the app is used, technical data may be processed, including account data, device information, app interactions, identifiers, diagnostics, and advertising-related data. Favorites are stored per user so they remain available after restarting the app and across multiple devices.\n\nProcessing is carried out to provide app functionality, authenticate users, store user-related settings, and finance the app through advertising.\n\nIt cannot be ruled out that integrated third-party services process data outside the European Union. In this respect, the privacy information of the respective services applies, especially Google Firebase and Google AdMob.\n\nFor privacy-related questions or deletion requests, please contact:\nasa.server.eye@gmail.com\n\nNote: Before a final public release, this privacy policy should be reviewed and expanded with full details on legal bases, retention periods, user rights, and all integrated services.';
 
   @override
-  String get imprintBody => 'Imprint / Legal Notice\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nGermany\n\nEmail:\nasa.server.eye@gmail.com\n\nResponsible for content:\nMichael Winkler';
+  String get imprintBody =>
+      'Imprint / Legal Notice\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nGermany\n\nEmail:\nasa.server.eye@gmail.com\n\nResponsible for content:\nMichael Winkler';
 
   @override
-  String get supportBody => 'Support\n\nFor questions, issues, or feedback about the app, please contact:\n\nMichael Winkler\nEmail: asa.server.eye@gmail.com\n\nPlease describe your issue as precisely as possible and include your device and app version if available.';
+  String get supportBody =>
+      'Support\n\nFor questions, issues, or feedback about the app, please contact:\n\nMichael Winkler\nEmail: asa.server.eye@gmail.com\n\nPlease describe your issue as precisely as possible and include your device and app version if available.';
 
   @override
   String get contactSupport => 'Contact support';
@@ -240,7 +246,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get supportEmailSubject => 'ASA Server Eye Support';
 
   @override
-  String get supportEmailBodyTemplate => 'Hello Michael,\n\nI have the following issue:\n\n\n---\nApp version:\nDevice:\n';
+  String get supportEmailBodyTemplate =>
+      'Hello Michael,\n\nI have the following issue:\n\n\n---\nApp version:\nDevice:\n';
 
   @override
   String get fullPrivacyPolicy => 'Full Privacy Policy';
@@ -273,7 +280,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileDeleteError => 'Account could not be deleted.';
 
   @override
-  String get deleteAccountHint => 'Deleting your account will remove your profile. Existing sightings will remain.';
+  String get deleteAccountHint =>
+      'Deleting your account will remove your profile. Existing sightings will remain.';
 
   @override
   String savedFavoritesCount(int count) {
@@ -284,13 +292,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get usernameEmpty => 'Please enter a username.';
 
   @override
-  String get usernameTooShort => 'The username must be at least 3 characters long.';
+  String get usernameTooShort =>
+      'The username must be at least 3 characters long.';
 
   @override
-  String get usernameTooLong => 'The username may be at most 20 characters long.';
+  String get usernameTooLong =>
+      'The username may be at most 20 characters long.';
 
   @override
-  String get usernameInvalidCharacters => 'The username may only contain letters, numbers, periods, underscores, and hyphens.';
+  String get usernameInvalidCharacters =>
+      'The username may only contain letters, numbers, periods, underscores, and hyphens.';
 
   @override
   String get deleteAccountDialogTitle => 'Delete account';
@@ -301,7 +312,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get signUpUsernameHint => 'This will be your public username visible to other users.';
+  String get signUpUsernameHint =>
+      'This will be your public username visible to other users.';
 
   @override
   String get emailHint => 'name@email.com';
@@ -379,13 +391,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sightingHideError => 'Sighting could not be hidden.';
 
   @override
-  String get sightingRequiresLogin => 'You must be logged in to report a sighting.';
+  String get sightingRequiresLogin =>
+      'You must be logged in to report a sighting.';
 
   @override
-  String get sightingDeleteNotAllowed => 'You are not allowed to delete this sighting.';
+  String get sightingDeleteNotAllowed =>
+      'You are not allowed to delete this sighting.';
 
   @override
-  String get sightingEditNotAllowed => 'You are not allowed to edit this sighting.';
+  String get sightingEditNotAllowed =>
+      'You are not allowed to edit this sighting.';
 
   @override
   String get sightingInGameNameRequired => 'Please enter a player name.';
@@ -400,7 +415,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sightingReasonRequired => 'Please enter a reason.';
 
   @override
-  String get sightingDeleteHint => 'This sighting will not be permanently deleted. It will only be hidden from normal users and remain traceable for admins.';
+  String get sightingDeleteHint =>
+      'This sighting will not be permanently deleted. It will only be hidden from normal users and remain traceable for admins.';
 
   @override
   String get reason => 'Reason';
@@ -445,7 +461,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get platformUnknown => 'Unknown';
 
   @override
-  String get sightingUserProfileLoadError => 'User profile could not be loaded.';
+  String get sightingUserProfileLoadError =>
+      'User profile could not be loaded.';
 
   @override
   String get playerSightings => 'Player Sightings';
@@ -520,25 +537,29 @@ class AppLocalizationsEn extends AppLocalizations {
   String get accountCreated => 'Account created successfully';
 
   @override
-  String get accountCreationFailed => 'Failed to create account. Please try again.';
+  String get accountCreationFailed =>
+      'Failed to create account. Please try again.';
 
   @override
   String get accountDeleted => 'Account deleted successfully';
 
   @override
-  String get accountDeletionFailed => 'Failed to delete account. Please try again.';
+  String get accountDeletionFailed =>
+      'Failed to delete account. Please try again.';
 
   @override
   String get deletePermanently => 'Delete permanently';
 
   @override
-  String get deletePermanentlyConfirmation => 'This sighting and its history will be permanently deleted. This action cannot be undone.';
+  String get deletePermanentlyConfirmation =>
+      'This sighting and its history will be permanently deleted. This action cannot be undone.';
 
   @override
   String get sightingDeletedPermanently => 'Sighting deleted permanently';
 
   @override
-  String get premiumRequiredForMoreFavorites => 'You need Premium to save more than one favorite.';
+  String get premiumRequiredForMoreFavorites =>
+      'You need Premium to save more than one favorite.';
 
   @override
   String get serversNavLabel => 'Servers';
@@ -562,25 +583,29 @@ class AppLocalizationsEn extends AppLocalizations {
   String get premiumHeadline => 'Unlock Premium';
 
   @override
-  String get premiumDescription => 'With Premium, you get access to player sightings, more favorites, and future premium features.';
+  String get premiumDescription =>
+      'With Premium, you get access to player sightings, more favorites, and future premium features.';
 
   @override
   String get premiumBenefitSightingsTitle => 'Player sightings';
 
   @override
-  String get premiumBenefitSightingsDescription => 'Access sightings directly from the navigation and use premium access across the sightings area.';
+  String get premiumBenefitSightingsDescription =>
+      'Access sightings directly from the navigation and use premium access across the sightings area.';
 
   @override
   String get premiumBenefitFavoritesTitle => 'More favorites';
 
   @override
-  String get premiumBenefitFavoritesDescription => 'Save significantly more servers to your favorites.';
+  String get premiumBenefitFavoritesDescription =>
+      'Save significantly more servers to your favorites.';
 
   @override
   String get premiumBenefitAlertsTitle => 'Future extras';
 
   @override
-  String get premiumBenefitAlertsDescription => 'Get ready for future premium features like enhanced tracking and alerts.';
+  String get premiumBenefitAlertsDescription =>
+      'Get ready for future premium features like enhanced tracking and alerts.';
 
   @override
   String get premiumMonthlyPlan => 'Monthly';
@@ -604,19 +629,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get restorePurchases => 'Restore purchases';
 
   @override
-  String get premiumPurchaseComingSoon => 'The purchase flow will be connected next.';
+  String get premiumPurchaseComingSoon =>
+      'The purchase flow will be connected next.';
 
   @override
   String get premiumUpgradeTitle => 'Upgrade to Premium';
 
   @override
-  String get premiumUpgradeDescription => 'Unlock the sightings tab and additional premium benefits.';
+  String get premiumUpgradeDescription =>
+      'Unlock the sightings tab and additional premium benefits.';
 
   @override
   String get premiumActiveTitle => 'Premium active';
 
   @override
-  String get premiumActiveDescription => 'Your account already has access to premium features.';
+  String get premiumActiveDescription =>
+      'Your account already has access to premium features.';
 
   @override
   String get unlockPremium => 'Unlock Premium';
@@ -625,28 +653,35 @@ class AppLocalizationsEn extends AppLocalizations {
   String get managePremium => 'Manage Premium';
 
   @override
-  String get premiumStoreUnavailable => 'The store is currently unavailable. Please try again later.';
+  String get premiumStoreUnavailable =>
+      'The store is currently unavailable. Please try again later.';
 
   @override
-  String get premiumProductsUnavailable => 'Currently, no premium products could be loaded.';
+  String get premiumProductsUnavailable =>
+      'Currently, no premium products could be loaded.';
 
   @override
-  String get premiumPurchaseError => 'An error occurred while purchasing. Please try again.';
+  String get premiumPurchaseError =>
+      'An error occurred while purchasing. Please try again.';
 
   @override
   String get premiumRestoreSuccess => 'Purchases restored successfully.';
 
   @override
-  String get premiumRestoreError => 'An error occurred while restoring purchases. Please try again.';
+  String get premiumRestoreError =>
+      'An error occurred while restoring purchases. Please try again.';
 
   @override
-  String get premiumPurchasePending => 'Your purchase is being processed. Premium will unlock after successful verification.';
+  String get premiumPurchasePending =>
+      'Your purchase is being processed. Premium will unlock after successful verification.';
 
   @override
-  String get premiumExpiredDescription => 'Your premium access has expired. You can unlock Premium again at any time.';
+  String get premiumExpiredDescription =>
+      'Your premium access has expired. You can unlock Premium again at any time.';
 
   @override
-  String get premiumVerificationQueued => 'Your purchase was submitted and is now being verified.';
+  String get premiumVerificationQueued =>
+      'Your purchase was submitted and is now being verified.';
 
   @override
   String get serverSyncSourceLive => 'Source: Live data';
@@ -696,7 +731,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get alertRulesLoadError => 'Alert rules could not be loaded.';
 
   @override
-  String get alertRulesRequiresLogin => 'You must be logged in to manage alert rules.';
+  String get alertRulesRequiresLogin =>
+      'You must be logged in to manage alert rules.';
 
   @override
   String get alertRuleType => 'Alert-Type';
@@ -705,7 +741,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get alertRuleThreshold => 'Threshold';
 
   @override
-  String get alertRuleThresholdHint => 'Enter player count or population percentage depending on the alert type.';
+  String get alertRuleThresholdHint =>
+      'Enter player count or population percentage depending on the alert type.';
 
   @override
   String get alertRuleThresholdRequired => 'Please enter a threshold value.';
@@ -726,7 +763,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteAlertRule => 'Delete Alert Rule';
 
   @override
-  String get deleteAlertRuleQuestion => 'Do you want to delete this alert rule?';
+  String get deleteAlertRuleQuestion =>
+      'Do you want to delete this alert rule?';
 
   @override
   String get alertRuleSaved => 'Alert rule saved.';
@@ -738,7 +776,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get alertRuleDeleted => 'Alert rule deleted.';
 
   @override
-  String get alertRuleMutationError => 'Alert rule could not be saved. Please try again.';
+  String get alertRuleMutationError =>
+      'Alert rule could not be saved. Please try again.';
 
   @override
   String get alertTypePopulationIncreased => 'Population increased';
@@ -757,4 +796,24 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get alertTypeServerOffline => 'Server offline';
+
+  @override
+  String get forgotPassword => 'Forgot password?';
+
+  @override
+  String get passwordResetEmailSent =>
+      'If an account exists for this email, a password reset link has been sent.';
+
+  @override
+  String get authMissingEmail => 'Please enter your email address.';
+
+  @override
+  String get resetPassword => 'Reset password';
+
+  @override
+  String get resetPasswordInstructions =>
+      'Enter your email address and we’ll send you a link to reset your password.';
+
+  @override
+  String get sendResetLink => 'Send reset link';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -139,7 +139,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get support => 'Soporte';
 
   @override
-  String get getHelpAndContactSupport => 'Obtener ayuda y contactar con soporte';
+  String get getHelpAndContactSupport =>
+      'Obtener ayuda y contactar con soporte';
 
   @override
   String comingSoon(String title) {
@@ -177,7 +178,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get welcomeBack => 'Bienvenido de nuevo';
 
   @override
-  String get signInToContinue => 'Inicia sesión para seguir usando tus datos guardados.';
+  String get signInToContinue =>
+      'Inicia sesión para seguir usando tus datos guardados.';
 
   @override
   String get createAccount => 'Crear cuenta';
@@ -186,7 +188,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get createYourAccount => 'Crea tu cuenta';
 
   @override
-  String get signUpToSaveFavorites => 'Regístrate para guardar tus favoritos en todos tus dispositivos.';
+  String get signUpToSaveFavorites =>
+      'Regístrate para guardar tus favoritos en todos tus dispositivos.';
 
   @override
   String get account => 'Cuenta';
@@ -198,10 +201,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get signOutDescription => 'Cerrar sesión de tu cuenta actual';
 
   @override
-  String get authMissingEmailOrPassword => 'Introduce tu correo electrónico y contraseña.';
+  String get authMissingEmailOrPassword =>
+      'Introduce tu correo electrónico y contraseña.';
 
   @override
-  String get authInvalidEmailFormat => 'Introduce una dirección de correo válida.';
+  String get authInvalidEmailFormat =>
+      'Introduce una dirección de correo válida.';
 
   @override
   String get authUserDisabled => 'Esta cuenta ha sido deshabilitada.';
@@ -213,34 +218,41 @@ class AppLocalizationsEs extends AppLocalizations {
   String get networkError => 'Error de red. Inténtalo de nuevo.';
 
   @override
-  String get authWeakPassword => 'La contraseña debe tener al menos 6 caracteres.';
+  String get authWeakPassword =>
+      'La contraseña debe tener al menos 6 caracteres.';
 
   @override
   String get authEmailAlreadyInUse => 'Este correo electrónico ya está en uso.';
 
   @override
-  String get aboutBody => 'ASA Server Eye es una aplicación complementaria para ARK: Survival Ascended. La aplicación muestra información de servidores, admite favoritos y constituye la base para futuras funciones como listas de seguimiento, notificaciones y funciones premium.\n\nDesarrollado y operado por:\nMichael Winkler\nCorreo electrónico: asa.server.eye@gmail.com';
+  String get aboutBody =>
+      'ASA Server Eye es una aplicación complementaria para ARK: Survival Ascended. La aplicación muestra información de servidores, admite favoritos y constituye la base para futuras funciones como listas de seguimiento, notificaciones y funciones premium.\n\nDesarrollado y operado por:\nMichael Winkler\nCorreo electrónico: asa.server.eye@gmail.com';
 
   @override
-  String get privacyBody => 'Política de privacidad\n\nResponsable del tratamiento de datos:\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nAlemania\nCorreo electrónico: asa.server.eye@gmail.com\n\nEsta aplicación utiliza Firebase Authentication para el inicio de sesión, Cloud Firestore para almacenar favoritos personales y Google AdMob para mostrar anuncios.\n\nDependiendo del uso de la aplicación, pueden procesarse datos técnicos, incluidos datos de cuenta, información del dispositivo, interacciones con la aplicación, identificadores, datos de diagnóstico y datos relacionados con la publicidad. Los favoritos se almacenan por usuario para que sigan disponibles después de reiniciar la aplicación y en varios dispositivos.\n\nEl tratamiento se realiza para proporcionar la funcionalidad de la aplicación, autenticar usuarios, guardar ajustes relacionados con el usuario y financiar la aplicación mediante publicidad.\n\nNo puede descartarse que los servicios de terceros integrados procesen datos fuera de la Unión Europea. En este sentido, también se aplican las políticas de privacidad de los servicios utilizados, en particular Google Firebase y Google AdMob.\n\nPara preguntas relacionadas con la privacidad o solicitudes de eliminación de datos, contacta con:\nasa.server.eye@gmail.com\n\nNota: Antes de una publicación pública definitiva, esta política de privacidad debería revisarse y ampliarse con información completa sobre bases legales, plazos de conservación, derechos de los usuarios y todos los servicios integrados.';
+  String get privacyBody =>
+      'Política de privacidad\n\nResponsable del tratamiento de datos:\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nAlemania\nCorreo electrónico: asa.server.eye@gmail.com\n\nEsta aplicación utiliza Firebase Authentication para el inicio de sesión, Cloud Firestore para almacenar favoritos personales y Google AdMob para mostrar anuncios.\n\nDependiendo del uso de la aplicación, pueden procesarse datos técnicos, incluidos datos de cuenta, información del dispositivo, interacciones con la aplicación, identificadores, datos de diagnóstico y datos relacionados con la publicidad. Los favoritos se almacenan por usuario para que sigan disponibles después de reiniciar la aplicación y en varios dispositivos.\n\nEl tratamiento se realiza para proporcionar la funcionalidad de la aplicación, autenticar usuarios, guardar ajustes relacionados con el usuario y financiar la aplicación mediante publicidad.\n\nNo puede descartarse que los servicios de terceros integrados procesen datos fuera de la Unión Europea. En este sentido, también se aplican las políticas de privacidad de los servicios utilizados, en particular Google Firebase y Google AdMob.\n\nPara preguntas relacionadas con la privacidad o solicitudes de eliminación de datos, contacta con:\nasa.server.eye@gmail.com\n\nNota: Antes de una publicación pública definitiva, esta política de privacidad debería revisarse y ampliarse con información completa sobre bases legales, plazos de conservación, derechos de los usuarios y todos los servicios integrados.';
 
   @override
-  String get imprintBody => 'Aviso legal\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nAlemania\n\nCorreo electrónico:\nasa.server.eye@gmail.com\n\nResponsable del contenido:\nMichael Winkler';
+  String get imprintBody =>
+      'Aviso legal\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nAlemania\n\nCorreo electrónico:\nasa.server.eye@gmail.com\n\nResponsable del contenido:\nMichael Winkler';
 
   @override
-  String get supportBody => 'Soporte\n\nPara preguntas, problemas o comentarios sobre la aplicación, contacta con:\n\nMichael Winkler\nCorreo electrónico: asa.server.eye@gmail.com\n\nDescribe tu problema lo más exactamente posible e incluye tu dispositivo y la versión de la aplicación si es posible.';
+  String get supportBody =>
+      'Soporte\n\nPara preguntas, problemas o comentarios sobre la aplicación, contacta con:\n\nMichael Winkler\nCorreo electrónico: asa.server.eye@gmail.com\n\nDescribe tu problema lo más exactamente posible e incluye tu dispositivo y la versión de la aplicación si es posible.';
 
   @override
   String get contactSupport => 'Contactar con soporte';
 
   @override
-  String get emailAppCouldNotBeOpened => 'No se pudo abrir la aplicación de correo.';
+  String get emailAppCouldNotBeOpened =>
+      'No se pudo abrir la aplicación de correo.';
 
   @override
   String get supportEmailSubject => 'Soporte de ASA Server Eye';
 
   @override
-  String get supportEmailBodyTemplate => 'Hola Michael,\n\ntengo el siguiente problema:\n\n\n---\nVersión de la app:\nDispositivo:\n';
+  String get supportEmailBodyTemplate =>
+      'Hola Michael,\n\ntengo el siguiente problema:\n\n\n---\nVersión de la app:\nDispositivo:\n';
 
   @override
   String get fullPrivacyPolicy => 'Política de privacidad completa';
@@ -273,7 +285,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileDeleteError => 'No se pudo eliminar la cuenta.';
 
   @override
-  String get deleteAccountHint => 'Eliminar tu cuenta quitará tu perfil. Los sightings existentes permanecerán.';
+  String get deleteAccountHint =>
+      'Eliminar tu cuenta quitará tu perfil. Los sightings existentes permanecerán.';
 
   @override
   String savedFavoritesCount(int count) {
@@ -284,13 +297,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get usernameEmpty => 'Introduce un nombre de usuario.';
 
   @override
-  String get usernameTooShort => 'El nombre de usuario debe tener al menos 3 caracteres.';
+  String get usernameTooShort =>
+      'El nombre de usuario debe tener al menos 3 caracteres.';
 
   @override
-  String get usernameTooLong => 'El nombre de usuario puede tener como máximo 20 caracteres.';
+  String get usernameTooLong =>
+      'El nombre de usuario puede tener como máximo 20 caracteres.';
 
   @override
-  String get usernameInvalidCharacters => 'El nombre de usuario solo puede contener letras, números, puntos, guiones bajos y guiones.';
+  String get usernameInvalidCharacters =>
+      'El nombre de usuario solo puede contener letras, números, puntos, guiones bajos y guiones.';
 
   @override
   String get deleteAccountDialogTitle => 'Eliminar cuenta';
@@ -301,7 +317,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get signUpUsernameHint => 'Este será tu nombre de usuario público visible para otros usuarios.';
+  String get signUpUsernameHint =>
+      'Este será tu nombre de usuario público visible para otros usuarios.';
 
   @override
   String get emailHint => 'nombre@email.com';
@@ -379,13 +396,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sightingHideError => 'No se pudo ocultar el avistamiento.';
 
   @override
-  String get sightingRequiresLogin => 'Debes iniciar sesión para reportar un avistamiento.';
+  String get sightingRequiresLogin =>
+      'Debes iniciar sesión para reportar un avistamiento.';
 
   @override
-  String get sightingDeleteNotAllowed => 'No tienes permiso para eliminar este avistamiento.';
+  String get sightingDeleteNotAllowed =>
+      'No tienes permiso para eliminar este avistamiento.';
 
   @override
-  String get sightingEditNotAllowed => 'No tienes permiso para editar este avistamiento.';
+  String get sightingEditNotAllowed =>
+      'No tienes permiso para editar este avistamiento.';
 
   @override
   String get sightingInGameNameRequired => 'Introduce un nombre de jugador.';
@@ -400,7 +420,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sightingReasonRequired => 'Introduce un motivo.';
 
   @override
-  String get sightingDeleteHint => 'Este avistamiento no se eliminará de forma permanente. Solo se ocultará para los usuarios normales y seguirá siendo rastreable para los administradores.';
+  String get sightingDeleteHint =>
+      'Este avistamiento no se eliminará de forma permanente. Solo se ocultará para los usuarios normales y seguirá siendo rastreable para los administradores.';
 
   @override
   String get reason => 'Motivo';
@@ -445,7 +466,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get platformUnknown => 'Desconocido';
 
   @override
-  String get sightingUserProfileLoadError => 'No se pudo cargar el perfil del usuario.';
+  String get sightingUserProfileLoadError =>
+      'No se pudo cargar el perfil del usuario.';
 
   @override
   String get playerSightings => 'Avistamientos de jugadores';
@@ -520,25 +542,30 @@ class AppLocalizationsEs extends AppLocalizations {
   String get accountCreated => 'Cuenta creada exitosamente';
 
   @override
-  String get accountCreationFailed => 'No se pudo crear la cuenta. Por favor, intenta de nuevo.';
+  String get accountCreationFailed =>
+      'No se pudo crear la cuenta. Por favor, intenta de nuevo.';
 
   @override
   String get accountDeleted => 'Cuenta eliminada exitosamente';
 
   @override
-  String get accountDeletionFailed => 'No se pudo eliminar la cuenta. Por favor, intenta de nuevo.';
+  String get accountDeletionFailed =>
+      'No se pudo eliminar la cuenta. Por favor, intenta de nuevo.';
 
   @override
   String get deletePermanently => 'Eliminar permanentemente';
 
   @override
-  String get deletePermanentlyConfirmation => 'Esta observación y su historial serán eliminados permanentemente. Esta acción no puede ser deshecha.';
+  String get deletePermanentlyConfirmation =>
+      'Esta observación y su historial serán eliminados permanentemente. Esta acción no puede ser deshecha.';
 
   @override
-  String get sightingDeletedPermanently => 'Avistamiento eliminado permanentemente';
+  String get sightingDeletedPermanently =>
+      'Avistamiento eliminado permanentemente';
 
   @override
-  String get premiumRequiredForMoreFavorites => 'Necesitas Premium para guardar más de un favorito.';
+  String get premiumRequiredForMoreFavorites =>
+      'Necesitas Premium para guardar más de un favorito.';
 
   @override
   String get serversNavLabel => 'Servidores';
@@ -562,25 +589,29 @@ class AppLocalizationsEs extends AppLocalizations {
   String get premiumHeadline => 'Mejora tu experiencia con Premium';
 
   @override
-  String get premiumDescription => 'Obtén acceso a funciones exclusivas, mejora tu experiencia y apoya el desarrollo continuo de la aplicación con una suscripción premium.';
+  String get premiumDescription =>
+      'Obtén acceso a funciones exclusivas, mejora tu experiencia y apoya el desarrollo continuo de la aplicación con una suscripción premium.';
 
   @override
   String get premiumBenefitSightingsTitle => 'Avistamientos de jugadores';
 
   @override
-  String get premiumBenefitSightingsDescription => 'Reporta avistamientos de jugadores en servidores específicos y hazlos visibles para otros usuarios premium.';
+  String get premiumBenefitSightingsDescription =>
+      'Reporta avistamientos de jugadores en servidores específicos y hazlos visibles para otros usuarios premium.';
 
   @override
   String get premiumBenefitFavoritesTitle => 'Más favoritos';
 
   @override
-  String get premiumBenefitFavoritesDescription => 'Guarda significativamente más servidores en tus favoritos.';
+  String get premiumBenefitFavoritesDescription =>
+      'Guarda significativamente más servidores en tus favoritos.';
 
   @override
   String get premiumBenefitAlertsTitle => 'Alertas y seguimiento';
 
   @override
-  String get premiumBenefitAlertsDescription => 'Prepárate para funciones premium futuras como el seguimiento mejorado y las alertas.';
+  String get premiumBenefitAlertsDescription =>
+      'Prepárate para funciones premium futuras como el seguimiento mejorado y las alertas.';
 
   @override
   String get premiumMonthlyPlan => 'Mensual';
@@ -610,13 +641,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get premiumUpgradeTitle => 'Mejora a Premium';
 
   @override
-  String get premiumUpgradeDescription => 'Actualiza a Premium para desbloquear funciones exclusivas y mejorar tu experiencia en ASA Server Eye.';
+  String get premiumUpgradeDescription =>
+      'Actualiza a Premium para desbloquear funciones exclusivas y mejorar tu experiencia en ASA Server Eye.';
 
   @override
   String get premiumActiveTitle => 'Premium activo';
 
   @override
-  String get premiumActiveDescription => 'Tu suscripción Premium está activa. Gracias por apoyar el desarrollo de la aplicación. Disfruta de tus funciones exclusivas y mantente atento a futuras mejoras.';
+  String get premiumActiveDescription =>
+      'Tu suscripción Premium está activa. Gracias por apoyar el desarrollo de la aplicación. Disfruta de tus funciones exclusivas y mantente atento a futuras mejoras.';
 
   @override
   String get unlockPremium => 'Desbloquear Premium';
@@ -628,25 +661,31 @@ class AppLocalizationsEs extends AppLocalizations {
   String get premiumStoreUnavailable => 'Tienda de premium no disponible';
 
   @override
-  String get premiumProductsUnavailable => 'Actualmente no se pueden cargar productos premium.';
+  String get premiumProductsUnavailable =>
+      'Actualmente no se pueden cargar productos premium.';
 
   @override
-  String get premiumPurchaseError => 'Error al comprar premium. Por favor, intenta de nuevo.';
+  String get premiumPurchaseError =>
+      'Error al comprar premium. Por favor, intenta de nuevo.';
 
   @override
   String get premiumRestoreSuccess => 'Compras restauradas exitosamente';
 
   @override
-  String get premiumRestoreError => 'Error al restaurar compras. Por favor, intenta de nuevo.';
+  String get premiumRestoreError =>
+      'Error al restaurar compras. Por favor, intenta de nuevo.';
 
   @override
-  String get premiumPurchasePending => 'Tu compra está siendo procesada. Premium se desbloqueará después de la verificación exitosa.';
+  String get premiumPurchasePending =>
+      'Tu compra está siendo procesada. Premium se desbloqueará después de la verificación exitosa.';
 
   @override
-  String get premiumExpiredDescription => 'Tu acceso premium ha expirado. Puedes desbloquear Premium nuevamente en cualquier momento.';
+  String get premiumExpiredDescription =>
+      'Tu acceso premium ha expirado. Puedes desbloquear Premium nuevamente en cualquier momento.';
 
   @override
-  String get premiumVerificationQueued => 'Tu compra fue enviada y ahora está siendo verificada.';
+  String get premiumVerificationQueued =>
+      'Tu compra fue enviada y ahora está siendo verificada.';
 
   @override
   String get serverSyncSourceLive => 'Fuente: Datos en vivo';
@@ -655,10 +694,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get serverSyncSourceCache => 'Fuente: Caché';
 
   @override
-  String get serverSyncCacheBanner => 'Se están mostrando datos de servidor en caché';
+  String get serverSyncCacheBanner =>
+      'Se están mostrando datos de servidor en caché';
 
   @override
-  String get serverSyncCacheStale => 'Los datos en caché podrían estar desactualizados';
+  String get serverSyncCacheStale =>
+      'Los datos en caché podrían estar desactualizados';
 
   @override
   String get serverSyncUnknownUpdateTime => 'Última actualización: Desconocida';
@@ -672,7 +713,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get serverSyncLoading => 'Cargando estado de sincronización…';
 
   @override
-  String get serverSyncUnavailable => 'El estado de sincronización no está disponible en este momento';
+  String get serverSyncUnavailable =>
+      'El estado de sincronización no está disponible en este momento';
 
   @override
   String get alertSettingsTitle => 'Reglas de alerta';
@@ -690,13 +732,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get editAlertRule => 'Editar regla de alerta';
 
   @override
-  String get noAlertRulesYet => 'Todavía no hay reglas de alerta para este servidor.';
+  String get noAlertRulesYet =>
+      'Todavía no hay reglas de alerta para este servidor.';
 
   @override
-  String get alertRulesLoadError => 'No se pudieron cargar las reglas de alerta.';
+  String get alertRulesLoadError =>
+      'No se pudieron cargar las reglas de alerta.';
 
   @override
-  String get alertRulesRequiresLogin => 'Debes iniciar sesión para gestionar las reglas de alerta.';
+  String get alertRulesRequiresLogin =>
+      'Debes iniciar sesión para gestionar las reglas de alerta.';
 
   @override
   String get alertRuleType => 'Tipo de alerta';
@@ -726,7 +771,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteAlertRule => 'Eliminar regla de alerta';
 
   @override
-  String get deleteAlertRuleQuestion => '¿Quieres eliminar esta regla de alerta?';
+  String get deleteAlertRuleQuestion =>
+      '¿Quieres eliminar esta regla de alerta?';
 
   @override
   String get alertRuleSaved => 'Regla de alerta guardada.';
@@ -738,7 +784,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get alertRuleDeleted => 'Regla de alerta eliminada.';
 
   @override
-  String get alertRuleMutationError => 'No se pudo guardar la regla de alerta. Inténtalo de nuevo.';
+  String get alertRuleMutationError =>
+      'No se pudo guardar la regla de alerta. Inténtalo de nuevo.';
 
   @override
   String get alertTypePopulationIncreased => 'La población aumentó';
@@ -757,4 +804,24 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get alertTypeServerOffline => 'Servidor fuera de línea';
+
+  @override
+  String get forgotPassword => '¿Olvidaste tu contraseña?';
+
+  @override
+  String get passwordResetEmailSent =>
+      'Si existe una cuenta para este correo, se ha enviado un enlace para restablecer la contraseña.';
+
+  @override
+  String get authMissingEmail => 'Introduce tu correo electrónico.';
+
+  @override
+  String get resetPassword => 'Restablecer contraseña';
+
+  @override
+  String get resetPasswordInstructions =>
+      'Introduce tu correo y te enviaremos un enlace para restablecer tu contraseña.';
+
+  @override
+  String get sendResetLink => 'Enviar enlace';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -27,7 +27,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noServersFound => 'Aucun serveur trouvé';
 
   @override
-  String get noServersMatchSearch => 'Aucun serveur ne correspond à votre recherche';
+  String get noServersMatchSearch =>
+      'Aucun serveur ne correspond à votre recherche';
 
   @override
   String get serverDetails => 'Détails du serveur';
@@ -139,7 +140,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get support => 'Support';
 
   @override
-  String get getHelpAndContactSupport => 'Obtenir de l\'aide et contacter le support';
+  String get getHelpAndContactSupport =>
+      'Obtenir de l\'aide et contacter le support';
 
   @override
   String comingSoon(String title) {
@@ -177,7 +179,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get welcomeBack => 'Bon retour';
 
   @override
-  String get signInToContinue => 'Connectez-vous pour continuer avec vos données enregistrées.';
+  String get signInToContinue =>
+      'Connectez-vous pour continuer avec vos données enregistrées.';
 
   @override
   String get createAccount => 'Créer un compte';
@@ -186,7 +189,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get createYourAccount => 'Créez votre compte';
 
   @override
-  String get signUpToSaveFavorites => 'Inscrivez-vous pour enregistrer vos favoris sur tous vos appareils.';
+  String get signUpToSaveFavorites =>
+      'Inscrivez-vous pour enregistrer vos favoris sur tous vos appareils.';
 
   @override
   String get account => 'Compte';
@@ -198,10 +202,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get signOutDescription => 'Se déconnecter du compte actuel';
 
   @override
-  String get authMissingEmailOrPassword => 'Veuillez saisir votre e-mail et votre mot de passe.';
+  String get authMissingEmailOrPassword =>
+      'Veuillez saisir votre e-mail et votre mot de passe.';
 
   @override
-  String get authInvalidEmailFormat => 'Veuillez saisir une adresse e-mail valide.';
+  String get authInvalidEmailFormat =>
+      'Veuillez saisir une adresse e-mail valide.';
 
   @override
   String get authUserDisabled => 'Ce compte a été désactivé.';
@@ -213,34 +219,41 @@ class AppLocalizationsFr extends AppLocalizations {
   String get networkError => 'Erreur réseau. Veuillez réessayer.';
 
   @override
-  String get authWeakPassword => 'Le mot de passe doit contenir au moins 6 caractères.';
+  String get authWeakPassword =>
+      'Le mot de passe doit contenir au moins 6 caractères.';
 
   @override
   String get authEmailAlreadyInUse => 'Cet e-mail est déjà utilisé.';
 
   @override
-  String get aboutBody => 'ASA Server Eye est une application compagnon pour ARK: Survival Ascended. L’application affiche des informations sur les serveurs, prend en charge les favoris et constitue la base de futures fonctionnalités telles que les listes de surveillance, les notifications et les fonctionnalités premium.\n\nDéveloppé et exploité par :\nMichael Winkler\nE-mail : asa.server.eye@gmail.com';
+  String get aboutBody =>
+      'ASA Server Eye est une application compagnon pour ARK: Survival Ascended. L’application affiche des informations sur les serveurs, prend en charge les favoris et constitue la base de futures fonctionnalités telles que les listes de surveillance, les notifications et les fonctionnalités premium.\n\nDéveloppé et exploité par :\nMichael Winkler\nE-mail : asa.server.eye@gmail.com';
 
   @override
-  String get privacyBody => 'Politique de confidentialité\n\nResponsable du traitement des données :\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nAllemagne\nE-mail : asa.server.eye@gmail.com\n\nCette application utilise Firebase Authentication pour la connexion aux comptes, Cloud Firestore pour stocker les favoris personnels et Google AdMob pour diffuser des publicités.\n\nSelon l’utilisation de l’application, des données techniques peuvent être traitées, notamment les données de compte, les informations sur l’appareil, les interactions avec l’application, les identifiants, les données de diagnostic et les données liées à la publicité. Les favoris sont stockés par utilisateur afin qu’ils restent disponibles après le redémarrage de l’application et sur plusieurs appareils.\n\nLe traitement est effectué afin de fournir les fonctionnalités de l’application, d’authentifier les utilisateurs, d’enregistrer les paramètres liés à l’utilisateur et de financer l’application par la publicité.\n\nIl ne peut être exclu que des services tiers intégrés traitent des données en dehors de l’Union européenne. À cet égard, les informations de confidentialité des services utilisés s’appliquent également, notamment Google Firebase et Google AdMob.\n\nPour toute question relative à la confidentialité ou pour demander la suppression de données, veuillez contacter :\nasa.server.eye@gmail.com\n\nRemarque : avant une publication publique définitive, cette politique de confidentialité devrait être relue et complétée avec des informations complètes sur les bases légales, les durées de conservation, les droits des utilisateurs et tous les services intégrés.';
+  String get privacyBody =>
+      'Politique de confidentialité\n\nResponsable du traitement des données :\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nAllemagne\nE-mail : asa.server.eye@gmail.com\n\nCette application utilise Firebase Authentication pour la connexion aux comptes, Cloud Firestore pour stocker les favoris personnels et Google AdMob pour diffuser des publicités.\n\nSelon l’utilisation de l’application, des données techniques peuvent être traitées, notamment les données de compte, les informations sur l’appareil, les interactions avec l’application, les identifiants, les données de diagnostic et les données liées à la publicité. Les favoris sont stockés par utilisateur afin qu’ils restent disponibles après le redémarrage de l’application et sur plusieurs appareils.\n\nLe traitement est effectué afin de fournir les fonctionnalités de l’application, d’authentifier les utilisateurs, d’enregistrer les paramètres liés à l’utilisateur et de financer l’application par la publicité.\n\nIl ne peut être exclu que des services tiers intégrés traitent des données en dehors de l’Union européenne. À cet égard, les informations de confidentialité des services utilisés s’appliquent également, notamment Google Firebase et Google AdMob.\n\nPour toute question relative à la confidentialité ou pour demander la suppression de données, veuillez contacter :\nasa.server.eye@gmail.com\n\nRemarque : avant une publication publique définitive, cette politique de confidentialité devrait être relue et complétée avec des informations complètes sur les bases légales, les durées de conservation, les droits des utilisateurs et tous les services intégrés.';
 
   @override
-  String get imprintBody => 'Mentions légales\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nAllemagne\n\nE-mail :\nasa.server.eye@gmail.com\n\nResponsable du contenu :\nMichael Winkler';
+  String get imprintBody =>
+      'Mentions légales\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\nAllemagne\n\nE-mail :\nasa.server.eye@gmail.com\n\nResponsable du contenu :\nMichael Winkler';
 
   @override
-  String get supportBody => 'Support\n\nPour toute question, problème ou retour concernant l’application, veuillez contacter :\n\nMichael Winkler\nE-mail : asa.server.eye@gmail.com\n\nVeuillez décrire votre problème aussi précisément que possible et inclure si possible votre appareil ainsi que la version de l’application.';
+  String get supportBody =>
+      'Support\n\nPour toute question, problème ou retour concernant l’application, veuillez contacter :\n\nMichael Winkler\nE-mail : asa.server.eye@gmail.com\n\nVeuillez décrire votre problème aussi précisément que possible et inclure si possible votre appareil ainsi que la version de l’application.';
 
   @override
   String get contactSupport => 'Contacter le support';
 
   @override
-  String get emailAppCouldNotBeOpened => 'Impossible d’ouvrir l’application e-mail.';
+  String get emailAppCouldNotBeOpened =>
+      'Impossible d’ouvrir l’application e-mail.';
 
   @override
   String get supportEmailSubject => 'Support ASA Server Eye';
 
   @override
-  String get supportEmailBodyTemplate => 'Bonjour Michael,\n\nj’ai le problème suivant :\n\n\n---\nVersion de l’application :\nAppareil :\n';
+  String get supportEmailBodyTemplate =>
+      'Bonjour Michael,\n\nj’ai le problème suivant :\n\n\n---\nVersion de l’application :\nAppareil :\n';
 
   @override
   String get fullPrivacyPolicy => 'Politique de confidentialité complète';
@@ -273,7 +286,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get profileDeleteError => 'Le compte n\'a pas pu être supprimé.';
 
   @override
-  String get deleteAccountHint => 'La suppression de votre compte supprimera votre profil. Les sightings existants resteront disponibles.';
+  String get deleteAccountHint =>
+      'La suppression de votre compte supprimera votre profil. Les sightings existants resteront disponibles.';
 
   @override
   String savedFavoritesCount(int count) {
@@ -284,13 +298,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get usernameEmpty => 'Veuillez saisir un nom d\'utilisateur.';
 
   @override
-  String get usernameTooShort => 'Le nom d\'utilisateur doit contenir au moins 3 caractères.';
+  String get usernameTooShort =>
+      'Le nom d\'utilisateur doit contenir au moins 3 caractères.';
 
   @override
-  String get usernameTooLong => 'Le nom d\'utilisateur ne peut pas dépasser 20 caractères.';
+  String get usernameTooLong =>
+      'Le nom d\'utilisateur ne peut pas dépasser 20 caractères.';
 
   @override
-  String get usernameInvalidCharacters => 'Le nom d\'utilisateur ne peut contenir que des lettres, chiffres, points, tirets bas et traits d\'union.';
+  String get usernameInvalidCharacters =>
+      'Le nom d\'utilisateur ne peut contenir que des lettres, chiffres, points, tirets bas et traits d\'union.';
 
   @override
   String get deleteAccountDialogTitle => 'Supprimer le compte';
@@ -301,7 +318,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get signUpUsernameHint => 'Ce sera votre nom d\'utilisateur public visible par les autres utilisateurs.';
+  String get signUpUsernameHint =>
+      'Ce sera votre nom d\'utilisateur public visible par les autres utilisateurs.';
 
   @override
   String get emailHint => 'nom@email.com';
@@ -373,25 +391,30 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sightingSaveError => 'Le signalement n\'a pas pu être enregistré.';
 
   @override
-  String get sightingUpdateError => 'Le signalement n\'a pas pu être mis à jour.';
+  String get sightingUpdateError =>
+      'Le signalement n\'a pas pu être mis à jour.';
 
   @override
   String get sightingHideError => 'Le signalement n\'a pas pu être masqué.';
 
   @override
-  String get sightingRequiresLogin => 'Vous devez être connecté pour signaler une observation.';
+  String get sightingRequiresLogin =>
+      'Vous devez être connecté pour signaler une observation.';
 
   @override
-  String get sightingDeleteNotAllowed => 'Vous n\'êtes pas autorisé à supprimer ce signalement.';
+  String get sightingDeleteNotAllowed =>
+      'Vous n\'êtes pas autorisé à supprimer ce signalement.';
 
   @override
-  String get sightingEditNotAllowed => 'Vous n\'êtes pas autorisé à modifier ce signalement.';
+  String get sightingEditNotAllowed =>
+      'Vous n\'êtes pas autorisé à modifier ce signalement.';
 
   @override
   String get sightingInGameNameRequired => 'Veuillez saisir un nom de joueur.';
 
   @override
-  String get sightingPlatformIdRequired => 'Veuillez saisir un ID de plateforme.';
+  String get sightingPlatformIdRequired =>
+      'Veuillez saisir un ID de plateforme.';
 
   @override
   String get sightingTribeNameRequired => 'Veuillez saisir un nom de tribu.';
@@ -400,7 +423,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sightingReasonRequired => 'Veuillez indiquer une raison.';
 
   @override
-  String get sightingDeleteHint => 'Ce signalement ne sera pas supprimé définitivement. Il sera seulement masqué pour les utilisateurs normaux et restera traçable pour les administrateurs.';
+  String get sightingDeleteHint =>
+      'Ce signalement ne sera pas supprimé définitivement. Il sera seulement masqué pour les utilisateurs normaux et restera traçable pour les administrateurs.';
 
   @override
   String get reason => 'Raison';
@@ -415,13 +439,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sightingsLoadError => 'Les sightings n\'ont pas pu être chargés.';
 
   @override
-  String get sightingHistoryLoadError => 'L\'historique n\'a pas pu être chargé.';
+  String get sightingHistoryLoadError =>
+      'L\'historique n\'a pas pu être chargé.';
 
   @override
   String get noSightingHistory => 'Aucun historique disponible pour le moment.';
 
   @override
-  String get accessLevelLoadError => 'Le niveau d\'accès n\'a pas pu être chargé.';
+  String get accessLevelLoadError =>
+      'Le niveau d\'accès n\'a pas pu être chargé.';
 
   @override
   String get edit => 'Modifier';
@@ -445,7 +471,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get platformUnknown => 'Inconnu';
 
   @override
-  String get sightingUserProfileLoadError => 'Le profil utilisateur n\'a pas pu être chargé.';
+  String get sightingUserProfileLoadError =>
+      'Le profil utilisateur n\'a pas pu être chargé.';
 
   @override
   String get playerSightings => 'Observations de joueurs';
@@ -520,25 +547,30 @@ class AppLocalizationsFr extends AppLocalizations {
   String get accountCreated => 'Compte créé avec succès';
 
   @override
-  String get accountCreationFailed => 'Échec de la création du compte. Veuillez réessayer.';
+  String get accountCreationFailed =>
+      'Échec de la création du compte. Veuillez réessayer.';
 
   @override
   String get accountDeleted => 'Compte supprimé avec succès';
 
   @override
-  String get accountDeletionFailed => 'Échec de la suppression du compte. Veuillez réessayer.';
+  String get accountDeletionFailed =>
+      'Échec de la suppression du compte. Veuillez réessayer.';
 
   @override
   String get deletePermanently => 'Supprimer définitivement';
 
   @override
-  String get deletePermanentlyConfirmation => 'Cette observation et son historique seront supprimés définitivement. Cette action ne peut pas être annulée.';
+  String get deletePermanentlyConfirmation =>
+      'Cette observation et son historique seront supprimés définitivement. Cette action ne peut pas être annulée.';
 
   @override
-  String get sightingDeletedPermanently => 'Observation supprimée définitivement';
+  String get sightingDeletedPermanently =>
+      'Observation supprimée définitivement';
 
   @override
-  String get premiumRequiredForMoreFavorites => 'Vous avez atteint la limite de favoris pour les utilisateurs gratuits. Passez à Premium pour enregistrer plus de favoris.';
+  String get premiumRequiredForMoreFavorites =>
+      'Vous avez atteint la limite de favoris pour les utilisateurs gratuits. Passez à Premium pour enregistrer plus de favoris.';
 
   @override
   String get serversNavLabel => 'Serveurs';
@@ -556,43 +588,50 @@ class AppLocalizationsFr extends AppLocalizations {
   String get premiumTitle => 'Premium';
 
   @override
-  String get premiumSettingsSubtitle => 'Découvrez les avantages de Premium et gérez votre abonnement.';
+  String get premiumSettingsSubtitle =>
+      'Découvrez les avantages de Premium et gérez votre abonnement.';
 
   @override
   String get premiumHeadline => 'Passez à Premium pour plus de fonctionnalités';
 
   @override
-  String get premiumDescription => 'Premium offre des fonctionnalités exclusives pour améliorer votre expérience avec ASA Server Eye, notamment l\'accès à la section des observations de joueurs, la possibilité d\'enregistrer plus de favoris et des extras à venir pour les utilisateurs Premium.';
+  String get premiumDescription =>
+      'Premium offre des fonctionnalités exclusives pour améliorer votre expérience avec ASA Server Eye, notamment l\'accès à la section des observations de joueurs, la possibilité d\'enregistrer plus de favoris et des extras à venir pour les utilisateurs Premium.';
 
   @override
   String get premiumBenefitSightingsTitle => 'Observations de joueurs';
 
   @override
-  String get premiumBenefitSightingsDescription => 'Accédez à la section exclusive des observations de joueurs pour signaler et consulter les activités suspectes en jeu.';
+  String get premiumBenefitSightingsDescription =>
+      'Accédez à la section exclusive des observations de joueurs pour signaler et consulter les activités suspectes en jeu.';
 
   @override
   String get premiumBenefitFavoritesTitle => 'Plus de favoris';
 
   @override
-  String get premiumBenefitFavoritesDescription => 'Enregistrez significativement plus de serveurs dans vos favoris.';
+  String get premiumBenefitFavoritesDescription =>
+      'Enregistrez significativement plus de serveurs dans vos favoris.';
 
   @override
   String get premiumBenefitAlertsTitle => 'Alertes et extras à venir';
 
   @override
-  String get premiumBenefitAlertsDescription => 'Bénéficiez d\'alertes personnalisées et d\'extras exclusifs à venir pour les utilisateurs Premium.';
+  String get premiumBenefitAlertsDescription =>
+      'Bénéficiez d\'alertes personnalisées et d\'extras exclusifs à venir pour les utilisateurs Premium.';
 
   @override
   String get premiumMonthlyPlan => 'Mensuel';
 
   @override
-  String get premiumMonthlyPlanDescription => 'Idéal pour essayer les fonctionnalités Premium et profiter d\'une flexibilité maximale.';
+  String get premiumMonthlyPlanDescription =>
+      'Idéal pour essayer les fonctionnalités Premium et profiter d\'une flexibilité maximale.';
 
   @override
   String get premiumYearlyPlan => 'Annuel';
 
   @override
-  String get premiumYearlyPlanDescription => 'Meilleure valeur pour un usage à long terme';
+  String get premiumYearlyPlanDescription =>
+      'Meilleure valeur pour un usage à long terme';
 
   @override
   String get premiumStartMonthly => 'Commencer mensuel';
@@ -610,13 +649,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get premiumUpgradeTitle => 'Passez à Premium';
 
   @override
-  String get premiumUpgradeDescription => 'Débloquez des fonctionnalités exclusives et améliorez votre expérience avec ASA Server Eye en passant à Premium.';
+  String get premiumUpgradeDescription =>
+      'Débloquez des fonctionnalités exclusives et améliorez votre expérience avec ASA Server Eye en passant à Premium.';
 
   @override
   String get premiumActiveTitle => 'Premium actif';
 
   @override
-  String get premiumActiveDescription => 'Vous profitez actuellement des avantages de Premium. Merci pour votre soutien !';
+  String get premiumActiveDescription =>
+      'Vous profitez actuellement des avantages de Premium. Merci pour votre soutien !';
 
   @override
   String get unlockPremium => 'Débloquer Premium';
@@ -625,28 +666,36 @@ class AppLocalizationsFr extends AppLocalizations {
   String get managePremium => 'Gérer Premium';
 
   @override
-  String get premiumStoreUnavailable => 'Le magasin de Premium n\'est pas disponible pour le moment. Veuillez réessayer plus tard.';
+  String get premiumStoreUnavailable =>
+      'Le magasin de Premium n\'est pas disponible pour le moment. Veuillez réessayer plus tard.';
 
   @override
-  String get premiumProductsUnavailable => 'Les produits Premium n\'ont pas pu être chargés pour le moment. Veuillez réessayer plus tard.';
+  String get premiumProductsUnavailable =>
+      'Les produits Premium n\'ont pas pu être chargés pour le moment. Veuillez réessayer plus tard.';
 
   @override
-  String get premiumPurchaseError => 'Une erreur s\'est produite lors de l\'achat de Premium. Veuillez réessayer.';
+  String get premiumPurchaseError =>
+      'Une erreur s\'est produite lors de l\'achat de Premium. Veuillez réessayer.';
 
   @override
-  String get premiumRestoreSuccess => 'Les achats ont été restaurés avec succès.';
+  String get premiumRestoreSuccess =>
+      'Les achats ont été restaurés avec succès.';
 
   @override
-  String get premiumRestoreError => 'Une erreur s\'est produite lors de la restauration des achats. Veuillez réessayer.';
+  String get premiumRestoreError =>
+      'Une erreur s\'est produite lors de la restauration des achats. Veuillez réessayer.';
 
   @override
-  String get premiumPurchasePending => 'Votre achat est en cours de traitement. Premium sera débloqué après vérification réussie.';
+  String get premiumPurchasePending =>
+      'Votre achat est en cours de traitement. Premium sera débloqué après vérification réussie.';
 
   @override
-  String get premiumExpiredDescription => 'Votre accès premium a expiré. Vous pouvez débloquer Premium à nouveau à tout moment.';
+  String get premiumExpiredDescription =>
+      'Votre accès premium a expiré. Vous pouvez débloquer Premium à nouveau à tout moment.';
 
   @override
-  String get premiumVerificationQueued => 'Votre achat a été soumis et est maintenant en cours de vérification.';
+  String get premiumVerificationQueued =>
+      'Votre achat a été soumis et est maintenant en cours de vérification.';
 
   @override
   String get serverSyncSourceLive => 'Source: Réseau';
@@ -655,10 +704,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get serverSyncSourceCache => 'Source: Cache';
 
   @override
-  String get serverSyncCacheBanner => 'Les données du serveur en cache sont affichées';
+  String get serverSyncCacheBanner =>
+      'Les données du serveur en cache sont affichées';
 
   @override
-  String get serverSyncCacheStale => 'Les données en cache pourraient être obsolètes';
+  String get serverSyncCacheStale =>
+      'Les données en cache pourraient être obsolètes';
 
   @override
   String get serverSyncUnknownUpdateTime => 'Dernière mise à jour: Inconnue';
@@ -672,7 +723,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get serverSyncLoading => 'Chargement de l’état de synchronisation…';
 
   @override
-  String get serverSyncUnavailable => 'L’état de synchronisation est actuellement indisponible';
+  String get serverSyncUnavailable =>
+      'L’état de synchronisation est actuellement indisponible';
 
   @override
   String get alertSettingsTitle => 'Règles d’alerte';
@@ -690,13 +742,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get editAlertRule => 'Modifier la règle d’alerte';
 
   @override
-  String get noAlertRulesYet => 'Aucune règle d’alerte pour ce serveur pour le moment.';
+  String get noAlertRulesYet =>
+      'Aucune règle d’alerte pour ce serveur pour le moment.';
 
   @override
-  String get alertRulesLoadError => 'Les règles d’alerte n’ont pas pu être chargées.';
+  String get alertRulesLoadError =>
+      'Les règles d’alerte n’ont pas pu être chargées.';
 
   @override
-  String get alertRulesRequiresLogin => 'Vous devez être connecté pour gérer les règles d’alerte.';
+  String get alertRulesRequiresLogin =>
+      'Vous devez être connecté pour gérer les règles d’alerte.';
 
   @override
   String get alertRuleType => 'Type d’alerte';
@@ -726,7 +781,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteAlertRule => 'Supprimer la règle d’alerte';
 
   @override
-  String get deleteAlertRuleQuestion => 'Voulez-vous supprimer cette règle d’alerte ?';
+  String get deleteAlertRuleQuestion =>
+      'Voulez-vous supprimer cette règle d’alerte ?';
 
   @override
   String get alertRuleSaved => 'Règle d’alerte enregistrée.';
@@ -738,7 +794,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get alertRuleDeleted => 'Règle d’alerte supprimée.';
 
   @override
-  String get alertRuleMutationError => 'La règle d’alerte n’a pas pu être enregistrée. Veuillez réessayer.';
+  String get alertRuleMutationError =>
+      'La règle d’alerte n’a pas pu être enregistrée. Veuillez réessayer.';
 
   @override
   String get alertTypePopulationIncreased => 'Population en hausse';
@@ -757,4 +814,24 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get alertTypeServerOffline => 'Serveur hors ligne';
+
+  @override
+  String get forgotPassword => 'Mot de passe oublié ?';
+
+  @override
+  String get passwordResetEmailSent =>
+      'Si un compte existe pour cet e-mail, un lien de réinitialisation a été envoyé.';
+
+  @override
+  String get authMissingEmail => 'Saisissez votre adresse e-mail.';
+
+  @override
+  String get resetPassword => 'Réinitialiser le mot de passe';
+
+  @override
+  String get resetPasswordInstructions =>
+      'Saisissez votre adresse e-mail et nous vous enverrons un lien de réinitialisation.';
+
+  @override
+  String get sendResetLink => 'Envoyer le lien';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -219,16 +219,20 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authEmailAlreadyInUse => '该电子邮件已被使用。';
 
   @override
-  String get aboutBody => 'ASA Server Eye 是一款适用于 ARK: Survival Ascended 的伴侣应用。该应用可显示服务器信息、支持收藏功能，并为后续的关注列表、通知和高级功能奠定基础。\n\n开发和运营者：\nMichael Winkler\n电子邮件：asa.server.eye@gmail.com';
+  String get aboutBody =>
+      'ASA Server Eye 是一款适用于 ARK: Survival Ascended 的伴侣应用。该应用可显示服务器信息、支持收藏功能，并为后续的关注列表、通知和高级功能奠定基础。\n\n开发和运营者：\nMichael Winkler\n电子邮件：asa.server.eye@gmail.com';
 
   @override
-  String get privacyBody => '隐私政策\n\n数据处理负责人：\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\n德国\n电子邮件：asa.server.eye@gmail.com\n\n本应用使用 Firebase Authentication 进行账户登录，使用 Cloud Firestore 存储个人收藏，并使用 Google AdMob 提供广告。\n\n根据应用的使用方式，可能会处理技术数据，包括账户数据、设备信息、应用交互、标识符、诊断数据以及与广告相关的数据。收藏内容会按用户存储，以便在重新启动应用后以及在多个设备之间继续可用。\n\n这些数据处理用于提供应用功能、验证用户身份、保存与用户相关的设置以及通过广告为应用提供资金支持。\n\n不能排除集成的第三方服务会在欧盟以外处理数据。在这方面，也适用相关服务各自的隐私信息，尤其是 Google Firebase 和 Google AdMob。\n\n如有与隐私相关的问题或数据删除请求，请联系：\nasa.server.eye@gmail.com\n\n注意：在最终公开发布之前，应再次审查并补充本隐私政策，包括法律依据、保存期限、用户权利以及所有集成服务的完整信息。';
+  String get privacyBody =>
+      '隐私政策\n\n数据处理负责人：\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\n德国\n电子邮件：asa.server.eye@gmail.com\n\n本应用使用 Firebase Authentication 进行账户登录，使用 Cloud Firestore 存储个人收藏，并使用 Google AdMob 提供广告。\n\n根据应用的使用方式，可能会处理技术数据，包括账户数据、设备信息、应用交互、标识符、诊断数据以及与广告相关的数据。收藏内容会按用户存储，以便在重新启动应用后以及在多个设备之间继续可用。\n\n这些数据处理用于提供应用功能、验证用户身份、保存与用户相关的设置以及通过广告为应用提供资金支持。\n\n不能排除集成的第三方服务会在欧盟以外处理数据。在这方面，也适用相关服务各自的隐私信息，尤其是 Google Firebase 和 Google AdMob。\n\n如有与隐私相关的问题或数据删除请求，请联系：\nasa.server.eye@gmail.com\n\n注意：在最终公开发布之前，应再次审查并补充本隐私政策，包括法律依据、保存期限、用户权利以及所有集成服务的完整信息。';
 
   @override
-  String get imprintBody => '法律声明\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\n德国\n\n电子邮件：\nasa.server.eye@gmail.com\n\n内容负责人：\nMichael Winkler';
+  String get imprintBody =>
+      '法律声明\n\nMichael Winkler\nAm Schülerheim 17\n14195 Berlin\n德国\n\n电子邮件：\nasa.server.eye@gmail.com\n\n内容负责人：\nMichael Winkler';
 
   @override
-  String get supportBody => '支持\n\n如果你对本应用有任何问题、故障或反馈，请联系：\n\nMichael Winkler\n电子邮件：asa.server.eye@gmail.com\n\n请尽可能准确地描述你的问题，并尽量附上你的设备信息和应用版本。';
+  String get supportBody =>
+      '支持\n\n如果你对本应用有任何问题、故障或反馈，请联系：\n\nMichael Winkler\n电子邮件：asa.server.eye@gmail.com\n\n请尽可能准确地描述你的问题，并尽量附上你的设备信息和应用版本。';
 
   @override
   String get contactSupport => '联系支持';
@@ -240,7 +244,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get supportEmailSubject => 'ASA Server Eye 支持';
 
   @override
-  String get supportEmailBodyTemplate => '你好 Michael，\n\n我遇到了以下问题：\n\n\n---\n应用版本：\n设备：\n';
+  String get supportEmailBodyTemplate =>
+      '你好 Michael，\n\n我遇到了以下问题：\n\n\n---\n应用版本：\n设备：\n';
 
   @override
   String get fullPrivacyPolicy => '完整隐私政策';
@@ -568,7 +573,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get premiumBenefitSightingsTitle => '玩家目击记录';
 
   @override
-  String get premiumBenefitSightingsDescription => '可直接通过导航访问目击记录，并在整个目击记录区域使用 Premium 权限。';
+  String get premiumBenefitSightingsDescription =>
+      '可直接通过导航访问目击记录，并在整个目击记录区域使用 Premium 权限。';
 
   @override
   String get premiumBenefitFavoritesTitle => '更多收藏';
@@ -580,7 +586,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get premiumBenefitAlertsTitle => '未来扩展功能';
 
   @override
-  String get premiumBenefitAlertsDescription => '为即将推出的 Premium 功能做好准备，例如增强监控和提醒。';
+  String get premiumBenefitAlertsDescription =>
+      '为即将推出的 Premium 功能做好准备，例如增强监控和提醒。';
 
   @override
   String get premiumMonthlyPlan => '月度';
@@ -757,4 +764,22 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get alertTypeServerOffline => '服务器离线';
+
+  @override
+  String get forgotPassword => '忘记密码？';
+
+  @override
+  String get passwordResetEmailSent => '如果此电子邮件对应的账户存在，密码重置链接已发送。';
+
+  @override
+  String get authMissingEmail => '请输入电子邮件地址。';
+
+  @override
+  String get resetPassword => '重置密码';
+
+  @override
+  String get resetPasswordInstructions => '请输入电子邮件地址，我们会向你发送密码重置链接。';
+
+  @override
+  String get sendResetLink => '发送重置链接';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1030,5 +1030,17 @@
     "alertTypeServerOffline": "服务器离线",
     "@alertTypeServerOffline": {
         "description": "提醒类型标签"
-    }
+    },
+    "forgotPassword": "忘记密码？",
+    "@forgotPassword": {
+        "description": "用于请求密码重置邮件的按钮"
+    },
+    "passwordResetEmailSent": "如果此电子邮件对应的账户存在，密码重置链接已发送。",
+    "@passwordResetEmailSent": {
+        "description": "请求密码重置邮件后的确认信息"
+    },
+    "authMissingEmail": "请输入电子邮件地址。",
+    "resetPassword": "重置密码",
+    "resetPasswordInstructions": "请输入电子邮件地址，我们会向你发送密码重置链接。",
+    "sendResetLink": "发送重置链接"
 }

--- a/test/features/auth/presentation/utils/auth_error_mapper_test.dart
+++ b/test/features/auth/presentation/utils/auth_error_mapper_test.dart
@@ -1,0 +1,37 @@
+import 'package:asa_server_eye/features/auth/presentation/utils/auth_error_mapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AuthErrorMapper.mapPasswordResetError', () {
+    const invalidEmail = 'invalid email';
+    const userDisabled = 'user disabled';
+    const networkError = 'network error';
+    const genericError = 'generic error';
+
+    String map(String code) {
+      return AuthErrorMapper.mapPasswordResetError(
+        code: code,
+        invalidEmailFormat: invalidEmail,
+        userDisabled: userDisabled,
+        networkError: networkError,
+        genericError: genericError,
+      );
+    }
+
+    test('maps invalid email errors', () {
+      expect(map('invalid-email'), invalidEmail);
+    });
+
+    test('maps disabled user errors', () {
+      expect(map('user-disabled'), userDisabled);
+    });
+
+    test('maps network errors', () {
+      expect(map('network-request-failed'), networkError);
+    });
+
+    test('does not expose unknown Firebase errors', () {
+      expect(map('internal-error'), genericError);
+    });
+  });
+}


### PR DESCRIPTION
## Zusammenfassung
- ergänzt einen dedizierten Passwort-Reset-Screen
- übernimmt eine bereits eingegebene Login-E-Mail
- validiert beim Reset ausschließlich die E-Mail-Adresse
- normalisiert die E-Mail vor Firebase Authentication
- bildet Firebase-Fehler sicher auf lokalisierte Meldungen ab
- ergänzt DE, EN, ES, FR und ZH
- testet den neuen Reset-Fehlermapper

## Ursache
Die bisherige Aktion verwendete den Login-Kontext und zeigte dadurch bei leerem Passwort fälschlich die kombinierte Meldung für E-Mail und Passwort.

## Datenschutz und Sicherheit
- neutrale Erfolgsbestätigung verhindert Account Enumeration
- keine E-Mail-Adressen, Tokens oder Secrets werden protokolliert
- Firebase Authentication bleibt die maßgebliche Auth-Instanz

## Verifikation
- `dart format` für den Feature-Scope
- `flutter analyze`
- `flutter test --coverage` (5 Tests erfolgreich)
- `flutter build apk --release`
- `flutter build appbundle --release`
- `flutter build ios --release --no-codesign`
- Diff- und Secret-Self-Review

Closes #100